### PR TITLE
Implement MusicXML import and export functionality

### DIFF
--- a/src/exporters/midi.ts
+++ b/src/exporters/midi.ts
@@ -32,9 +32,15 @@ export function exportMidi(score: Score, options: MidiExportOptions = {}): Uint8
   // Create a track for each part
   for (let partIndex = 0; partIndex < score.parts.length; partIndex++) {
     const part = score.parts[partIndex];
-    const partInfo = score.partList[partIndex];
-    const channel = partInfo?.midiInstrument?.channel ?? partIndex % 16;
-    const program = partInfo?.midiInstrument?.program ?? 1;
+    const partEntry = score.partList[partIndex];
+    // Only score-part entries have MIDI instruments
+    let channel = partIndex % 16;
+    let program = 1;
+    if (partEntry && partEntry.type === 'score-part' && partEntry.midiInstruments?.[0]) {
+      const midiInst = partEntry.midiInstruments[0];
+      channel = midiInst.channel ?? channel;
+      program = midiInst.program ?? program;
+    }
 
     const trackData = createPartTrack(
       part,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ export type {
   Score,
   ScoreMetadata,
   PartInfo,
+  PartGroup,
+  PartListEntry,
   Part,
   Measure,
   MeasureAttributes,
@@ -14,10 +16,10 @@ export type {
   Pitch,
   NoteType,
   Accidental,
+  AccidentalInfo,
   TieInfo,
   BeamInfo,
   Notation,
-  NotationType,
   DirectionType,
   DynamicsValue,
   Lyric,
@@ -31,6 +33,9 @@ export type {
   NoteWithPosition,
   Chord,
   NoteIteratorItem,
+  Print,
+  Defaults,
+  Credit,
 } from './types';
 
 // Importers

--- a/tests/accessors.test.ts
+++ b/tests/accessors.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { parse } from '../src/parser';
+import { parse } from '../src';
 import {
   getNotesForVoice,
   getNotesForStaff,

--- a/tests/compressed.test.ts
+++ b/tests/compressed.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { parse } from '../src/parser';
-import { serialize } from '../src/serializer';
+import { parse } from '../src';
+import { serialize } from '../src';
 import {
   parseCompressed,
   serializeCompressed,
   isCompressed,
   parseAuto,
-} from '../src/compressed';
+} from '../src';
 
 const fixturesPath = join(__dirname, 'fixtures');
 const lilypondPath = join(fixturesPath, 'lilypond', 'xmlFiles');
@@ -66,13 +66,13 @@ describe('Compressed MusicXML (.mxl)', () => {
       const xml = readFileSync(join(fixturesPath, 'basic/single-note.xml'), 'utf-8');
       const score = parse(xml);
       score.metadata.workTitle = 'Test Compression';
-      score.metadata.creator = { composer: 'Test Composer' };
+      score.metadata.creators = [{ type: 'composer', value: 'Test Composer' }];
 
       const mxlData = serializeCompressed(score);
       const parsedBack = parseCompressed(mxlData);
 
       expect(parsedBack.metadata.workTitle).toBe('Test Compression');
-      expect(parsedBack.metadata.creator?.composer).toBe('Test Composer');
+      expect(parsedBack.metadata.creators?.find(c => c.type === 'composer')?.value).toBe('Test Composer');
     });
   });
 

--- a/tests/file.test.ts
+++ b/tests/file.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { readFileSync, unlinkSync, existsSync } from 'fs';
 import { join } from 'path';
-import { parse } from '../src/parser';
+import { parse } from '../src';
 import { parseFile, serializeToFile } from '../src/file';
-import { isCompressed } from '../src/compressed';
+import { isCompressed } from '../src';
 
 const fixturesPath = join(__dirname, 'fixtures');
 const lilypondPath = join(fixturesPath, 'lilypond', 'xmlFiles');

--- a/tests/operations.test.ts
+++ b/tests/operations.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { parse } from '../src/parser';
+import { parse } from '../src';
 import {
   transpose,
   addNote,

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { parse } from '../src/parser';
+import { parse } from '../src';
 
 const fixturesPath = join(__dirname, 'fixtures');
 
@@ -12,10 +12,14 @@ describe('Parser', () => {
       const score = parse(xml);
 
       expect(score.metadata.workTitle).toBe('Single Note');
-      expect(score.metadata.creator?.composer).toBe('Test');
+      expect(score.metadata.creators?.find(c => c.type === 'composer')?.value).toBe('Test');
       expect(score.partList).toHaveLength(1);
-      expect(score.partList[0].id).toBe('P1');
-      expect(score.partList[0].name).toBe('Piano');
+      const part0 = score.partList[0];
+      expect(part0.type).toBe('score-part');
+      if (part0.type === 'score-part') {
+        expect(part0.id).toBe('P1');
+        expect(part0.name).toBe('Piano');
+      }
 
       expect(score.parts).toHaveLength(1);
       expect(score.parts[0].measures).toHaveLength(1);

--- a/tests/roundtrip.test.ts
+++ b/tests/roundtrip.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
-import { parse } from '../src/parser';
-import { serialize } from '../src/serializer';
+import { parse } from '../src';
+import { serialize } from '../src';
 
 const fixturesPath = join(__dirname, 'fixtures');
 

--- a/tests/serializer.test.ts
+++ b/tests/serializer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { serialize } from '../src/serializer';
+import { serialize } from '../src';
 import type { Score } from '../src/types';
 
 describe('Serializer', () => {
@@ -10,6 +10,7 @@ describe('Serializer', () => {
       },
       partList: [
         {
+          type: 'score-part',
           id: 'P1',
           name: 'Piano',
         },
@@ -68,7 +69,7 @@ describe('Serializer', () => {
   it('should serialize a chord', () => {
     const score: Score = {
       metadata: {},
-      partList: [{ id: 'P1', name: 'Piano' }],
+      partList: [{ type: 'score-part', id: 'P1', name: 'Piano' }],
       parts: [
         {
           id: 'P1',
@@ -114,7 +115,7 @@ describe('Serializer', () => {
   it('should serialize backup and forward', () => {
     const score: Score = {
       metadata: {},
-      partList: [{ id: 'P1', name: 'Test' }],
+      partList: [{ type: 'score-part', id: 'P1', name: 'Test' }],
       parts: [
         {
           id: 'P1',
@@ -142,7 +143,7 @@ describe('Serializer', () => {
   it('should serialize with version 3.1', () => {
     const score: Score = {
       metadata: {},
-      partList: [{ id: 'P1', name: 'Test' }],
+      partList: [{ type: 'score-part', id: 'P1', name: 'Test' }],
       parts: [{ id: 'P1', measures: [] }],
     };
 
@@ -157,7 +158,7 @@ describe('Serializer', () => {
       metadata: {
         workTitle: 'Test & "Quotes" <Tags>',
       },
-      partList: [{ id: 'P1', name: 'Test' }],
+      partList: [{ type: 'score-part', id: 'P1', name: 'Test' }],
       parts: [{ id: 'P1', measures: [] }],
     };
 
@@ -169,7 +170,7 @@ describe('Serializer', () => {
   it('should serialize directions', () => {
     const score: Score = {
       metadata: {},
-      partList: [{ id: 'P1', name: 'Test' }],
+      partList: [{ type: 'score-part', id: 'P1', name: 'Test' }],
       parts: [
         {
           id: 'P1',
@@ -209,7 +210,7 @@ describe('Serializer', () => {
   it('should serialize notations', () => {
     const score: Score = {
       metadata: {},
-      partList: [{ id: 'P1', name: 'Test' }],
+      partList: [{ type: 'score-part', id: 'P1', name: 'Test' }],
       parts: [
         {
           id: 'P1',
@@ -223,8 +224,8 @@ describe('Serializer', () => {
                   duration: 4,
                   voice: 1,
                   notations: [
-                    { type: 'staccato' },
-                    { type: 'slur', startStop: 'start', number: 1 },
+                    { type: 'articulation', articulation: 'staccato' },
+                    { type: 'slur', slurType: 'start', number: 1 },
                   ],
                 },
               ],


### PR DESCRIPTION
Major changes:
- Restructure type system with discriminated unions (PartListEntry, Notation types)
- Add full support for defaults (appearance, music-font, word-font, lyric-font, lyric-language)
- Add support for print element with system-layout, page-layout
- Add support for credits with credit-words
- Add note layout attributes (default-x, default-y)
- Add score-instrument and midi-instrument support in part-list
- Add part-group support
- Add rest info (display-step, display-octave)
- Add notehead support
- Add tuplet notation support
- Add accidental info with cautionary/editorial/parentheses
- Fix encoding with supports elements
- Fix miscellaneous field parsing/serialization
- Update tests to match new type structure