### PR TITLE
Implement MusicXML import and export functionality

### DIFF
--- a/src/exporters/midi.ts
+++ b/src/exporters/midi.ts
@@ -122,7 +122,8 @@ function createConductorTrack(
         if (entry.type === 'direction') {
           for (const dirType of entry.directionTypes) {
             if (dirType.kind === 'metronome') {
-              const bpm = dirType.perMinute;
+              const bpm = typeof dirType.perMinute === 'number' ? dirType.perMinute : parseInt(String(dirType.perMinute), 10);
+              if (isNaN(bpm)) continue;
               const usPerQuarter = Math.round(60000000 / bpm);
               const tickDelta = (measurePosition * ticksPerQuarterNote) / divisions;
 


### PR DESCRIPTION
Add support for:
- Harmony (chord symbols) with root, kind, bass, degrees, and frame
- Figured bass elements
- Staff details with tuning for TAB staves
- Measure style (multiple-rest, measure-repeat, slash)
- Non-traditional key signatures (key-step, key-alter, key-octave)
- Clef octave-change
- Direction offset
- Direction types: bracket, dashes, accordion-registration
- Words attributes (default-x/y, font-*)
- Wavy-line and tremolo with values in ornaments
- Tuplet-actual/tuplet-normal details
- Score instrument solo/ensemble
- Score-part group elements
- Multiple tie elements per note
- Metronome with beat-unit-tied (tempo ratio)
- Slur attributes (bezier, default-x/y)
- Time-modification normal-dots