### PR TITLE
Implement MusicXML import and export functionality

### DIFF
--- a/src/exporters/musicxml.ts
+++ b/src/exporters/musicxml.ts
@@ -941,7 +941,8 @@ function serializeNote(note: NoteEntry, indent: string): string[] {
 
   // Type
   if (note.noteType) {
-    lines.push(`${indent}  <type>${note.noteType}</type>`);
+    const typeAttrs = note.noteTypeSize ? ` size="${escapeXml(note.noteTypeSize)}"` : '';
+    lines.push(`${indent}  <type${typeAttrs}>${note.noteType}</type>`);
   }
 
   // Dots
@@ -1283,8 +1284,10 @@ function serializeNotationsGroup(notations: Notation[], indent: string): string[
     lines.push(`${indent}  <technical>`);
     for (const tech of technicals) {
       if (tech.type === 'technical') {
-        const placementAttr = tech.placement ? ` placement="${tech.placement}"` : '';
+        let placementAttr = tech.placement ? ` placement="${tech.placement}"` : '';
         const techNotation = tech as TechnicalNotation;
+        if (techNotation.defaultX !== undefined) placementAttr += ` default-x="${techNotation.defaultX}"`;
+        if (techNotation.defaultY !== undefined) placementAttr += ` default-y="${techNotation.defaultY}"`;
         if (tech.technical === 'bend' && (techNotation.bendAlter !== undefined || techNotation.preBend || techNotation.release)) {
           lines.push(`${indent}    <bend${placementAttr}>`);
           if (techNotation.bendAlter !== undefined) {
@@ -1443,6 +1446,7 @@ function serializeDirection(direction: DirectionEntry, indent: string): string[]
   let attrs = '';
   if (direction.placement) attrs += ` placement="${direction.placement}"`;
   if (direction.directive) attrs += ' directive="yes"';
+  if (direction.system) attrs += ` system="${direction.system}"`;
   lines.push(`${indent}<direction${attrs}>`);
 
   for (const dirType of direction.directionTypes) {
@@ -1609,8 +1613,14 @@ function serializeDirectionType(dirType: DirectionType, indent: string): string[
       lines.push(`${indent}  </accordion-registration>`);
       break;
 
-    case 'other-direction':
-      lines.push(`${indent}  <other-direction>${escapeXml(dirType.text)}</other-direction>`);
+    case 'other-direction': {
+      let otherAttrs = '';
+      if (dirType.defaultX !== undefined) otherAttrs += ` default-x="${dirType.defaultX}"`;
+      if (dirType.defaultY !== undefined) otherAttrs += ` default-y="${dirType.defaultY}"`;
+      if (dirType.halign) otherAttrs += ` halign="${escapeXml(dirType.halign)}"`;
+      if (dirType.printObject === false) otherAttrs += ' print-object="no"';
+      lines.push(`${indent}  <other-direction${otherAttrs}>${escapeXml(dirType.text)}</other-direction>`);
+    }
       break;
 
     case 'segno':

--- a/src/types.ts
+++ b/src/types.ts
@@ -351,6 +351,7 @@ export interface NoteEntry {
 
   // Note details
   noteType?: NoteType;
+  noteTypeSize?: string;
   dots?: number;
   accidental?: AccidentalInfo;
   stem?: StemInfo;
@@ -416,6 +417,7 @@ export interface DirectionEntry {
   offset?: number;
   offsetSound?: boolean;
   sound?: DirectionSound;
+  system?: 'only-top' | 'also-top' | 'none';
 }
 
 export interface Swing {
@@ -657,6 +659,9 @@ export interface TechnicalNotation extends BaseNotation {
   startStop?: 'start' | 'stop';
   // For heel, toe
   substitution?: boolean;
+  // Positioning
+  defaultX?: number;
+  defaultY?: number;
 }
 
 export type TechnicalType =
@@ -764,7 +769,7 @@ export type DirectionType =
   | { kind: 'scordatura'; accords?: Accord[] }
   | { kind: 'harp-pedals'; pedalTunings?: PedalTuning[] }
   | { kind: 'image'; source?: string; type?: string }
-  | { kind: 'other-direction'; text: string };
+  | { kind: 'other-direction'; text: string; defaultX?: number; defaultY?: number; halign?: string; printObject?: boolean };
 
 export interface Accord {
   string: number;


### PR DESCRIPTION
Major improvements:
- Add scordatura/accord element parsing and serialization
- Add harp-pedals direction type support
- Add harmonic children (natural/artificial/base-pitch/etc.)
- Add hammer-on/pull-off type attribute
- Add accidental-mark to ornaments
- Add accidental positioning attributes (relative-x/y, color, size, font-size)
- Add `note/@dynamics` and note/@print-object attributes
- Add `key/@print-object` attribute
- Add metronome attributes (parentheses, default-y, font-family, font-size)
- Add harmony positioning attributes (default-y, font-size)
- Add strong-accent type attribute
- Add grace steal-time attributes
- Add `fingering/@substitution` and /`@alternate` attributes
- Add toe/heel substitution attribute
- Add words/`@justify` and /`@color` attributes
- Add first-fret to frame with text and location
- Add other-dynamics support in notations
- Fix metronome per-minute to be optional (for tempo ratio notation)