### PR TITLE
Improve Importer/Exporter with Clair de Lune score

### DIFF
--- a/src/exporters/musicxml.ts
+++ b/src/exporters/musicxml.ts
@@ -1615,6 +1615,7 @@ function serializeDirectionType(dirType: DirectionType, indent: string): string[
       if (dirType.defaultX !== undefined) wordAttrs += ` default-x="${dirType.defaultX}"`;
       if (dirType.defaultY !== undefined) wordAttrs += ` default-y="${dirType.defaultY}"`;
       if (dirType.relativeX !== undefined) wordAttrs += ` relative-x="${dirType.relativeX}"`;
+      if (dirType.relativeY !== undefined) wordAttrs += ` relative-y="${dirType.relativeY}"`;
       if (dirType.fontFamily) wordAttrs += ` font-family="${escapeXml(dirType.fontFamily)}"`;
       if (dirType.fontSize) wordAttrs += ` font-size="${escapeXml(dirType.fontSize)}"`;
       if (dirType.fontStyle) wordAttrs += ` font-style="${escapeXml(dirType.fontStyle)}"`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -778,7 +778,7 @@ export type DirectionType =
   | { kind: 'dynamics'; value: DynamicsValue; defaultX?: number; defaultY?: number; relativeX?: number; halign?: string }
   | { kind: 'wedge'; type: 'crescendo' | 'diminuendo' | 'stop'; spread?: number; defaultY?: number; relativeX?: number }
   | { kind: 'metronome'; beatUnit: NoteType; perMinute?: number | string; beatUnitDot?: boolean; beatUnit2?: NoteType; beatUnitDot2?: boolean; parentheses?: boolean; defaultY?: number; fontFamily?: string; fontSize?: string }
-  | { kind: 'words'; text: string; defaultX?: number; defaultY?: number; relativeX?: number; fontFamily?: string; fontSize?: string; fontStyle?: string; fontWeight?: string; xmlLang?: string; justify?: string; color?: string; xmlSpace?: string; halign?: string }
+  | { kind: 'words'; text: string; defaultX?: number; defaultY?: number; relativeX?: number; relativeY?: number; fontFamily?: string; fontSize?: string; fontStyle?: string; fontWeight?: string; xmlLang?: string; justify?: string; color?: string; xmlSpace?: string; halign?: string }
   | { kind: 'rehearsal'; text: string; enclosure?: string; defaultX?: number; defaultY?: number; fontSize?: string; fontWeight?: string }
   | { kind: 'segno' }
   | { kind: 'coda' }


### PR DESCRIPTION
### Fixed
- Direction parsing: Fixed parsing of multiple <words> elements within a single <direction-type>. Previously only the first element was captured, causing text like "con sordina" to be lost in complex scores.
- Cross-staff beam validation: Fixed false positive validation errors for cross-staff beaming in piano scores. Beams spanning multiple staves within the same voice are now correctly validated.

### Added
- relativeY attribute support: Added support for relative-y positioning attribute on <words> direction types in both importer and exporter.
### Changed
- Internal refactor: parseDirectionType() renamed to parseDirectionTypes() and now returns an array to properly handle multiple direction type elements.