### PR TITLE
Add UTF-16 encoding support for MusicXML parsing

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -37,14 +37,12 @@ export async function parseFile(filePath: string): Promise<Score> {
 export function decodeBuffer(buffer: Buffer): string {
   // UTF-16 BE BOM: FE FF
   if (buffer.length >= 2 && buffer[0] === 0xFE && buffer[1] === 0xFF) {
-    return buffer.swap16().toString('utf-16le'); // Node.js usually handles LE well, or just use ucs2
-    // Actually Node's utf16le is standard. efficient way to read BE is swap and read LE or use TextDecoder.
-    // simpler: TextDecoder
+    return new TextDecoder('utf-16be').decode(buffer);
   }
 
   // UTF-16 LE BOM: FF FE
   if (buffer.length >= 2 && buffer[0] === 0xFF && buffer[1] === 0xFE) {
-    return buffer.toString('utf16le');
+    return new TextDecoder('utf-16le').decode(buffer);
   }
 
   // UTF-8 BOM: EF BB BF

--- a/src/importers/musicxml-compressed.ts
+++ b/src/importers/musicxml-compressed.ts
@@ -67,6 +67,25 @@ export function isCompressed(data: Uint8Array): boolean {
 }
 
 /**
+ * Detect encoding from BOM and decode Uint8Array to string
+ * Supports UTF-8, UTF-16BE, UTF-16LE
+ */
+function decodeXmlBytes(data: Uint8Array): string {
+  // UTF-16 BE BOM: FE FF
+  if (data.length >= 2 && data[0] === 0xFE && data[1] === 0xFF) {
+    return new TextDecoder('utf-16be').decode(data);
+  }
+
+  // UTF-16 LE BOM: FF FE
+  if (data.length >= 2 && data[0] === 0xFF && data[1] === 0xFE) {
+    return new TextDecoder('utf-16le').decode(data);
+  }
+
+  // Default to UTF-8 (TextDecoder handles UTF-8 BOM automatically)
+  return new TextDecoder('utf-8').decode(data);
+}
+
+/**
  * Parse either compressed (.mxl) or uncompressed (.xml/.musicxml) MusicXML
  * Automatically detects the format
  * @param data - The file data as Uint8Array or string
@@ -81,7 +100,7 @@ export function parseAuto(data: Uint8Array | string): Score {
     return parseCompressed(data);
   }
 
-  // Assume it's uncompressed XML
-  const xmlString = strFromU8(data);
+  // Decode with encoding detection (handles UTF-16 and UTF-8)
+  const xmlString = decodeXmlBytes(data);
   return parse(xmlString);
 }

--- a/tests/file.test.ts
+++ b/tests/file.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { readFileSync, unlinkSync, existsSync } from 'fs';
 import { join } from 'path';
 import { parse } from '../src';
-import { parseFile, serializeToFile } from '../src/file';
-import { isCompressed } from '../src';
+import { parseFile, serializeToFile, decodeBuffer } from '../src/file';
+import { isCompressed, parseAuto } from '../src';
 
 const fixturesPath = join(__dirname, 'fixtures');
 const lilypondPath = join(fixturesPath, 'lilypond', 'xmlFiles');
@@ -42,6 +42,66 @@ describe('File Operations', () => {
       const score = await parseFile(filePath);
 
       expect(score.parts.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('decodeBuffer / UTF-16 encoding', () => {
+    const minimalXml = '<?xml version="1.0" encoding="UTF-8"?>\n<score-partwise version="4.0"><part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list><part id="P1"><measure number="1"><note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><type>whole</type></note></measure></part></score-partwise>';
+
+    it('should decode UTF-16 LE buffer (with BOM)', () => {
+      // Build UTF-16 LE buffer: BOM (FF FE) + UTF-16 LE encoded string
+      const utf16leBuf = Buffer.from('\uFEFF' + minimalXml, 'utf16le');
+      const decoded = decodeBuffer(utf16leBuf);
+      expect(decoded).not.toContain('\uFEFF');
+      expect(decoded).toContain('score-partwise');
+      expect(decoded).toContain('<step>C</step>');
+    });
+
+    it('should decode UTF-16 BE buffer (with BOM)', () => {
+      // Build UTF-16 BE buffer: BOM (FE FF) + big-endian encoded chars
+      const chars = '\uFEFF' + minimalXml;
+      const utf16beBuf = Buffer.alloc(chars.length * 2);
+      for (let i = 0; i < chars.length; i++) {
+        utf16beBuf.writeUInt16BE(chars.charCodeAt(i), i * 2);
+      }
+      const decoded = decodeBuffer(utf16beBuf);
+      expect(decoded).not.toContain('\uFEFF');
+      expect(decoded).toContain('score-partwise');
+      expect(decoded).toContain('<step>C</step>');
+    });
+
+    it('should parse a UTF-16 LE XML file via parseFile', async () => {
+      const sourcePath = join(fixturesPath, 'basic/single-note.xml');
+      const utf8Content = readFileSync(sourcePath, 'utf-8');
+      const utf16leBuf = Buffer.from('\uFEFF' + utf8Content, 'utf16le');
+
+      const tmpPath = join(__dirname, 'temp', 'single-note-utf16le.xml');
+      const { writeFileSync } = await import('fs');
+      writeFileSync(tmpPath, utf16leBuf);
+      cleanupFiles.push(tmpPath);
+
+      const score = await parseFile(tmpPath);
+      expect(score.metadata.workTitle).toBe('Single Note');
+      expect(score.parts[0].measures[0].entries[0].type).toBe('note');
+    });
+
+    it('should parse a UTF-16 LE Uint8Array via parseAuto', () => {
+      const utf16leBytes = new Uint8Array(Buffer.from('\uFEFF' + minimalXml, 'utf16le'));
+      const score = parseAuto(utf16leBytes);
+      expect(score.parts).toHaveLength(1);
+      expect(score.parts[0].measures).toHaveLength(1);
+    });
+
+    it('should parse a UTF-16 BE Uint8Array via parseAuto', () => {
+      const chars = '\uFEFF' + minimalXml;
+      const utf16beBytes = new Uint8Array(chars.length * 2);
+      for (let i = 0; i < chars.length; i++) {
+        utf16beBytes[i * 2] = chars.charCodeAt(i) >> 8;
+        utf16beBytes[i * 2 + 1] = chars.charCodeAt(i) & 0xFF;
+      }
+      const score = parseAuto(utf16beBytes);
+      expect(score.parts).toHaveLength(1);
+      expect(score.parts[0].measures).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive UTF-16 encoding support to the MusicXML parser, enabling it to correctly handle MusicXML files encoded in UTF-16 BE (Big Endian) and UTF-16 LE (Little Endian) formats with proper BOM (Byte Order Mark) detection.

## Key Changes
- **Enhanced `decodeBuffer()` function** in `src/file.ts`: Replaced Node.js buffer encoding methods with `TextDecoder` API for more reliable UTF-16 handling, supporting both UTF-16 BE and UTF-16 LE with BOM detection
- **New `decodeXmlBytes()` function** in `src/importers/musicxml-compressed.ts`: Implements encoding detection logic for Uint8Array inputs, supporting UTF-8, UTF-16 BE, and UTF-16 LE
- **Updated `parseAuto()` function**: Now uses the new `decodeXmlBytes()` function instead of `strFromU8()` to properly handle UTF-16 encoded MusicXML data
- **Comprehensive test coverage** in `tests/file.test.ts`: Added 5 new test cases covering:
  - UTF-16 LE buffer decoding with BOM
  - UTF-16 BE buffer decoding with BOM
  - File parsing via `parseFile()` with UTF-16 LE encoding
  - Uint8Array parsing via `parseAuto()` for both UTF-16 LE and BE formats

## Implementation Details
- Uses the standard `TextDecoder` API for consistent cross-platform encoding detection and conversion
- Detects encoding based on BOM markers (FE FF for UTF-16 BE, FF FE for UTF-16 LE)
- Falls back to UTF-8 decoding when no UTF-16 BOM is detected
- Maintains backward compatibility with existing UTF-8 encoded files

https://claude.ai/code/session_01T1QrABdqXTUZyrp7z1Ptbo