### PR TITLE
Make parse() accept Uint8Array/Buffer and recover from NUL-byte strings

### DIFF
--- a/src/importers/musicxml.ts
+++ b/src/importers/musicxml.ts
@@ -108,7 +108,36 @@ function decodeTree(nodes: XmlChild[]): void {
 // Reusable txml options: empty noChildNodes skips the default HTML void-element check.
 const TXML_OPTIONS = { noChildNodes: [] as string[] };
 
-export function parse(xmlString: string): Score {
+/**
+ * Decode a Uint8Array / Buffer to a UTF-8 string, handling UTF-16 BE/LE BOMs.
+ */
+function decodeXmlBytes(data: Uint8Array): string {
+  // UTF-16 BE BOM: FE FF
+  if (data.length >= 2 && data[0] === 0xFE && data[1] === 0xFF) {
+    return new TextDecoder('utf-16be').decode(data);
+  }
+  // UTF-16 LE BOM: FF FE
+  if (data.length >= 2 && data[0] === 0xFF && data[1] === 0xFE) {
+    return new TextDecoder('utf-16le').decode(data);
+  }
+  // Default to UTF-8 (handles UTF-8 BOM automatically)
+  return new TextDecoder('utf-8').decode(data);
+}
+
+export function parse(input: string | Uint8Array): Score {
+  let xmlString: string;
+
+  if (typeof input !== 'string') {
+    // Buffer / Uint8Array: decode with BOM-based encoding detection
+    xmlString = decodeXmlBytes(input);
+  } else if (input.includes('\x00')) {
+    // String contains NUL bytes — UTF-16 data was read as UTF-8 by the caller.
+    // Strip NUL bytes to recover the ASCII content (works for standard MusicXML).
+    xmlString = input.replace(/\x00/g, '');
+  } else {
+    xmlString = input;
+  }
+
   // Strip Processing Instructions (<?...?>) except the XML declaration (<?xml ...?>).
   // Some exporters (e.g. Guitar Pro 7) embed PIs like <?GP7 ...?> that txml cannot handle.
   const cleanedXml = xmlString.replace(/<\?(?!xml\s)[^?]*\?>/g, '');

--- a/tests/file.test.ts
+++ b/tests/file.test.ts
@@ -103,6 +103,48 @@ describe('File Operations', () => {
       expect(score.parts).toHaveLength(1);
       expect(score.parts[0].measures).toHaveLength(1);
     });
+
+    it('should parse a UTF-16 LE Uint8Array directly via parse()', () => {
+      // parse() now accepts Uint8Array/Buffer directly
+      const utf16leBytes = new Uint8Array(Buffer.from('\uFEFF' + minimalXml, 'utf16le'));
+      const score = parse(utf16leBytes);
+      expect(score.parts).toHaveLength(1);
+      expect(score.parts[0].measures[0].entries[0].type).toBe('note');
+    });
+
+    it('should parse a UTF-16 BE Buffer directly via parse()', () => {
+      const chars = '\uFEFF' + minimalXml;
+      const utf16beBuf = Buffer.alloc(chars.length * 2);
+      for (let i = 0; i < chars.length; i++) {
+        utf16beBuf.writeUInt16BE(chars.charCodeAt(i), i * 2);
+      }
+      const score = parse(utf16beBuf);
+      expect(score.parts).toHaveLength(1);
+      expect(score.parts[0].measures[0].entries[0].type).toBe('note');
+    });
+
+    it('should recover when UTF-16 BE file is misread as UTF-8 string (NUL bytes in string)', () => {
+      // Simulate: readFileSync('utf16be.xml', 'utf-8') — produces NUL-byte-laden string
+      const chars = '\uFEFF' + minimalXml;
+      const utf16beBuf = Buffer.alloc(chars.length * 2);
+      for (let i = 0; i < chars.length; i++) {
+        utf16beBuf.writeUInt16BE(chars.charCodeAt(i), i * 2);
+      }
+      // This is what readFileSync('file', 'utf-8') returns for a UTF-16 BE file
+      const garbledString = utf16beBuf.toString('utf-8');
+      expect(garbledString).toContain('\x00'); // confirm NUL bytes present
+      const score = parse(garbledString);
+      expect(score.parts).toHaveLength(1);
+      expect(score.parts[0].measures[0].entries[0].type).toBe('note');
+    });
+
+    it('should parse MozaChloSample.musicxml (real UTF-16 BE file) via parse() with Buffer', async () => {
+      const { readFileSync } = await import('fs');
+      const buf = readFileSync(join(fixturesPath, 'musicxml_samples/MozaChloSample.musicxml'));
+      const score = parse(new Uint8Array(buf));
+      expect(score.metadata?.workTitle).toBe('An Chloe (Page 1)');
+      expect(score.parts.length).toBe(2);
+    });
   });
 
   describe('serializeToFile', () => {


### PR DESCRIPTION
Users who call readFileSync('file', 'utf-8') on a UTF-16 file receive a string full of NUL bytes (\0) before every character. Previously this caused infinite recursion in txml.

Two-layer fix in parse():
- If input is Uint8Array/Buffer: decode via TextDecoder with BOM detection (UTF-16 BE/LE handled correctly before txml ever sees the string)
- If input is a string containing NUL bytes: strip them — recovers the ASCII content when UTF-16 data was misread as UTF-8 by the caller

Also adds tests covering parse(Uint8Array), parse(Buffer), the NUL-byte recovery path, and end-to-end parsing of MozaChloSample.musicxml.

https://claude.ai/code/session_01T1QrABdqXTUZyrp7z1Ptbo