### PR TITLE
Sanitize XML control characters and improve UTF-16 error handling

### DIFF
--- a/src/importers/musicxml.ts
+++ b/src/importers/musicxml.ts
@@ -82,14 +82,26 @@ function decodeXmlEntities(s: string): string {
   );
 }
 
+/**
+ * Characters forbidden in XML 1.0 text content:
+ *   C0 controls except TAB (#x9), LF (#xA), CR (#xD)
+ *   plus the non-characters U+FFFE and U+FFFF
+ * Reference: https://www.w3.org/TR/xml/#charsets
+ */
+const INVALID_XML_CHARS_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\uFFFE\uFFFF]/g;
+
 /** Recursively decode XML entities in all text nodes and attribute values */
 function decodeTree(nodes: XmlChild[]): void {
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
     if (typeof node === 'string') {
-      if (node.indexOf('&') !== -1) {
-        nodes[i] = decodeXmlEntities(node);
+      let s = node;
+      if (s.indexOf('&') !== -1) {
+        s = decodeXmlEntities(s);
       }
+      // Strip characters forbidden by XML 1.0 (e.g. control char U+0019 from malformed sources
+      // or from numeric entity references like &#25; that decode to invalid characters)
+      nodes[i] = s.replace(INVALID_XML_CHARS_RE, '');
     } else {
       // Decode attribute values
       const attrs = node.attributes as Record<string, string>;

--- a/src/importers/musicxml.ts
+++ b/src/importers/musicxml.ts
@@ -143,9 +143,18 @@ export function parse(input: string | Uint8Array): Score {
     // Buffer / Uint8Array: decode with BOM-based encoding detection
     xmlString = decodeXmlBytes(input);
   } else if (input.includes('\x00')) {
-    // String contains NUL bytes — UTF-16 data was read as UTF-8 by the caller.
-    // Strip NUL bytes to recover the ASCII content (works for standard MusicXML).
-    xmlString = input.replace(/\x00/g, '');
+    // NUL bytes in a string mean the caller read a UTF-16 file without encoding detection
+    // (e.g. fs.readFileSync(path, 'binary')). Silently stripping NULs only works for
+    // ASCII content and corrupts non-ASCII characters (e.g. U+2019 → U+0019).
+    // The correct fix is to pass a Buffer or Uint8Array so the library can detect the
+    // BOM and decode properly.
+    throw new Error(
+      'parse() received a string containing NUL bytes, which indicates a UTF-16 encoded ' +
+      'MusicXML file was read without proper encoding detection. ' +
+      'Pass a Buffer or Uint8Array instead so the encoding is handled automatically:\n' +
+      '  parse(fs.readFileSync(path))          // Node.js\n' +
+      '  parse(new Uint8Array(arrayBuffer))    // Browser'
+    );
   } else {
     xmlString = input;
   }

--- a/tests/file.test.ts
+++ b/tests/file.test.ts
@@ -123,19 +123,17 @@ describe('File Operations', () => {
       expect(score.parts[0].measures[0].entries[0].type).toBe('note');
     });
 
-    it('should recover when UTF-16 BE file is misread as UTF-8 string (NUL bytes in string)', () => {
-      // Simulate: readFileSync('utf16be.xml', 'utf-8') — produces NUL-byte-laden string
+    it('should throw a helpful error when UTF-16 file is passed as a NUL-byte string', () => {
+      // Simulate: readFileSync('utf16be.xml', 'binary') — produces NUL-byte-laden string
       const chars = '\uFEFF' + minimalXml;
       const utf16beBuf = Buffer.alloc(chars.length * 2);
       for (let i = 0; i < chars.length; i++) {
         utf16beBuf.writeUInt16BE(chars.charCodeAt(i), i * 2);
       }
-      // This is what readFileSync('file', 'utf-8') returns for a UTF-16 BE file
-      const garbledString = utf16beBuf.toString('utf-8');
+      const garbledString = utf16beBuf.toString('binary');
       expect(garbledString).toContain('\x00'); // confirm NUL bytes present
-      const score = parse(garbledString);
-      expect(score.parts).toHaveLength(1);
-      expect(score.parts[0].measures[0].entries[0].type).toBe('note');
+      // parse() should throw rather than silently corrupt non-ASCII characters
+      expect(() => parse(garbledString)).toThrow(/Buffer or Uint8Array/);
     });
 
     it('should parse MozaChloSample.musicxml (real UTF-16 BE file) via parse() with Buffer', async () => {

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -247,4 +247,71 @@ describe('Parser', () => {
       expect(midMeasureClef!.position).toBe(504);
     });
   });
+
+  describe('control character sanitization', () => {
+    // Minimal MusicXML template with a single note that has a lyric
+    function makeLyricXml(lyricText: string): string {
+      return `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Test</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration><voice>1</voice><type>whole</type>
+        <lyric number="1"><syllabic>single</syllabic><text>${lyricText}</text></lyric>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    }
+
+    it('should strip raw C0 control characters (e.g. U+0019) from lyric text', () => {
+      // 0x19 is a control character forbidden by XML 1.0
+      const xml = makeLyricXml('Lieb\x19mir');
+      const score = parse(xml);
+      const note = score.parts[0].measures[0].entries[0];
+      expect(note.type).toBe('note');
+      if (note.type === 'note') {
+        // For a single <text> element, parseLyric stores the text in lyric.text directly
+        expect(note.lyrics?.[0].text).toBe('Liebmir');
+      }
+    });
+
+    it('should strip control characters encoded as numeric XML entities (e.g. &#25;)', () => {
+      // &#25; is decimal 25 = 0x19, also forbidden in XML 1.0
+      const xml = makeLyricXml('Lieb&#25;mir');
+      const score = parse(xml);
+      const note = score.parts[0].measures[0].entries[0];
+      expect(note.type).toBe('note');
+      if (note.type === 'note') {
+        expect(note.lyrics?.[0].text).toBe('Liebmir');
+      }
+    });
+
+    it('should preserve valid whitespace characters (tab) in lyric text', () => {
+      // Tab (0x09) is legal in XML 1.0
+      const xml = makeLyricXml('A\tB');
+      const score = parse(xml);
+      const note = score.parts[0].measures[0].entries[0];
+      expect(note.type).toBe('note');
+      if (note.type === 'note') {
+        expect(note.lyrics?.[0].text).toBe('A\tB');
+      }
+    });
+
+    it('should strip all C0 control chars except TAB/LF/CR', () => {
+      // Build a string with chars 0x00-0x1F; only TAB (0x09), LF (0x0A), CR (0x0D) should survive
+      const allC0 = Array.from({ length: 32 }, (_, i) => String.fromCharCode(i)).join('');
+      const xml = makeLyricXml(`A${allC0}B`);
+      const score = parse(xml);
+      const note = score.parts[0].measures[0].entries[0];
+      expect(note.type).toBe('note');
+      if (note.type === 'note') {
+        const text = note.lyrics?.[0].text ?? '';
+        // After stripping forbidden chars, only A, TAB (0x09), LF (0x0A), CR (0x0D), B remain
+        expect(text).toBe('A\x09\x0A\x0DB');
+      }
+    });
+  });
 });

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -301,9 +301,10 @@ describe('Parser', () => {
     });
 
     it('should strip all C0 control chars except TAB/LF/CR', () => {
-      // Build a string with chars 0x00-0x1F; only TAB (0x09), LF (0x0A), CR (0x0D) should survive
-      const allC0 = Array.from({ length: 32 }, (_, i) => String.fromCharCode(i)).join('');
-      const xml = makeLyricXml(`A${allC0}B`);
+      // Build a string with chars 0x01-0x1F (skip 0x00: NUL triggers the UTF-16 misread error)
+      // Only TAB (0x09), LF (0x0A), CR (0x0D) should survive stripping.
+      const c0NoBOM = Array.from({ length: 31 }, (_, i) => String.fromCharCode(i + 1)).join('');
+      const xml = makeLyricXml(`A${c0NoBOM}B`);
       const score = parse(xml);
       const note = score.parts[0].measures[0].entries[0];
       expect(note.type).toBe('note');


### PR DESCRIPTION
## Summary
This PR improves the robustness of MusicXML parsing by sanitizing forbidden XML control characters and providing better error messages for encoding issues.

## Key Changes

- **Control character sanitization**: Added a regex-based filter to strip C0 control characters (U+0000–U+001F) that are forbidden in XML 1.0, except for the valid whitespace characters TAB (U+0009), LF (U+000A), and CR (U+000D). This handles both raw control bytes and numeric XML entities (e.g., `&#25;`) that decode to invalid characters.

- **Improved UTF-16 error handling**: Changed the behavior when a string containing NUL bytes is passed to `parse()`. Instead of silently stripping NUL bytes (which corrupts non-ASCII characters), the function now throws a descriptive error message directing users to pass a Buffer or Uint8Array for proper encoding detection.

- **Updated test expectations**: Modified the UTF-16 misread test to verify that an error is thrown with helpful guidance, rather than attempting silent recovery.

## Implementation Details

- The sanitization regex `[\x00-\x08\x0B\x0C\x0E-\x1F\uFFFE\uFFFF]` is applied to all text nodes during XML tree decoding, ensuring control characters are removed regardless of their source.
- The error message for NUL-byte strings includes concrete examples for both Node.js and browser environments.
- All existing valid whitespace handling is preserved; only forbidden control characters are removed.

https://claude.ai/code/session_01UidRVBYMATBd3Te87WRaG3