### PR TITLE
feat(midi): expand repeats/voltas/jumps and add expressive playback

### DIFF
--- a/src/exporters/midi.ts
+++ b/src/exporters/midi.ts
@@ -1,5 +1,6 @@
-import type { Score, NoteEntry, Pitch, Part, Measure } from '../types';
+import type { Score, NoteEntry, Pitch, Part, Measure, DynamicsValue } from '../types';
 import { hasTieStart, hasTieStop } from '../entry-accessors';
+import { generatePlaybackSequence } from '../query/playback-sequence';
 
 /**
  * MIDI export options
@@ -9,8 +10,113 @@ export interface MidiExportOptions {
   ticksPerQuarterNote?: number;
   /** Default tempo in BPM (default: 120) */
   defaultTempo?: number;
-  /** Default velocity for notes (default: 80) */
+  /** Default velocity for notes when no dynamics are present (default: 80) */
   defaultVelocity?: number;
+}
+
+/**
+ * Absolute dynamic markings mapped to MIDI velocity.
+ * Mirrors the validated mapping used by the Octava playback engine.
+ */
+const DYNAMICS_VELOCITY: Partial<Record<DynamicsValue, number>> = {
+  pppppp: 12, ppppp: 20, pppp: 25, ppp: 30, pp: 40, p: 50,
+  mp: 60, mf: 75,
+  f: 90, ff: 105, fff: 115, ffff: 120, fffff: 125, ffffff: 127,
+  fp: 90, // forte-piano: forte attack
+  n: 25, // niente
+  pf: 70,
+};
+
+/**
+ * Sforzando-family markings are relative accents applied to the current
+ * baseline velocity rather than absolute levels.
+ */
+const SF_ACCENT_MULTIPLIER: Partial<Record<DynamicsValue, number>> = {
+  sf: 1.3, sfz: 1.35, sffz: 1.45, fz: 1.3, rf: 1.2, rfz: 1.3, sfp: 1.3, sfpp: 1.3,
+};
+
+/**
+ * Articulation velocity multipliers (accents). Duration-affecting
+ * articulations (staccato etc.) are intentionally not handled here.
+ */
+const ARTICULATION_VELOCITY: Record<string, number> = {
+  'accent': 1.25,
+  'strong-accent': 1.35,
+  'marcato': 1.35,
+  'tenuto': 1.05,
+  'stress': 1.15,
+  'unstress': 0.85,
+  'soft-accent': 0.8,
+};
+
+/** Velocity scaling for grace notes (slightly softer than their principal). */
+const GRACE_VELOCITY_MULTIPLIER = 0.85;
+
+function clampVelocity(v: number): number {
+  return Math.round(Math.min(127, Math.max(1, v)));
+}
+
+/**
+ * Combined articulation velocity multiplier for a note's notations.
+ */
+function articulationVelocityMultiplier(note: NoteEntry): number {
+  if (!note.notations) return 1;
+  let mult = 1;
+  for (const n of note.notations) {
+    if (n.type === 'articulation') {
+      const m = ARTICULATION_VELOCITY[n.articulation];
+      if (m) mult *= m;
+    }
+  }
+  return mult;
+}
+
+interface MidiNoteEvent {
+  tick: number;
+  type: 'on' | 'off';
+  note: number;
+  velocity: number;
+}
+
+/**
+ * Schedule grace notes immediately before the beat of their principal note,
+ * matching the validated Octava behaviour (grace notes precede the onset and
+ * borrow time from before it rather than delaying the principal note).
+ *
+ * Chord grace notes (chord=true) share their predecessor's time slot.
+ */
+function scheduleGraceNotes(
+  graceNotes: NoteEntry[],
+  targetTick: number,
+  baseVelocity: number,
+  chromaticTranspose: number,
+  ticksPerQuarterNote: number,
+  noteEvents: MidiNoteEvent[]
+): void {
+  if (graceNotes.length === 0) return;
+
+  const graceUnit = Math.max(1, Math.round(ticksPerQuarterNote / 8)); // ~32nd note
+
+  // Assign a time slot to each grace note; chord notes reuse the prior slot.
+  const slots: number[] = [];
+  let slot = -1;
+  for (const g of graceNotes) {
+    if (!g.chord || slot < 0) slot++;
+    slots.push(slot);
+  }
+  const numSlots = slot + 1;
+  const velocity = clampVelocity(baseVelocity * GRACE_VELOCITY_MULTIPLIER);
+
+  for (let i = 0; i < graceNotes.length; i++) {
+    const g = graceNotes[i];
+    if (!g.pitch) continue;
+    const s = slots[i];
+    const onset = Math.max(0, targetTick - (numSlots - s) * graceUnit);
+    const off = Math.max(onset + 1, targetTick - (numSlots - s - 1) * graceUnit);
+    const midiNote = pitchToMidiNote(g.pitch, chromaticTranspose);
+    noteEvents.push({ tick: onset, type: 'on', note: midiNote, velocity });
+    noteEvents.push({ tick: off, type: 'off', note: midiNote, velocity: 0 });
+  }
 }
 
 /**
@@ -26,8 +132,13 @@ export function exportMidi(score: Score, options: MidiExportOptions = {}): Uint8
 
   const tracks: Uint8Array[] = [];
 
+  // Expand repeats, voltas, and jump instructions (D.C./D.S./Coda/Fine) into
+  // the actual order measures should be played. Structure is read from the
+  // first part and applied to every part so all tracks stay in sync.
+  const measureOrder = generatePlaybackSequence(score).map((m) => m.measureIndex);
+
   // Track 0: Tempo and time signature
-  const conductorTrack = createConductorTrack(score, defaultTempo, ticksPerQuarterNote);
+  const conductorTrack = createConductorTrack(score, defaultTempo, ticksPerQuarterNote, measureOrder);
   tracks.push(conductorTrack);
 
   // Create a track for each part
@@ -52,7 +163,8 @@ export function exportMidi(score: Score, options: MidiExportOptions = {}): Uint8
       channel,
       program,
       ticksPerQuarterNote,
-      defaultVelocity
+      defaultVelocity,
+      measureOrder
     );
     tracks.push(trackData);
   }
@@ -77,87 +189,183 @@ function pitchToMidiNote(pitch: Pitch, chromaticTranspose: number = 0): number {
 }
 
 /**
- * Create conductor track (tempo, time signature, key signature)
+ * Maximum position (in divisions) reached within a measure, accounting for
+ * multi-voice writing via backup/forward. Grace notes carry no duration and
+ * therefore do not advance the position.
+ */
+function measureMaxPosition(measure: Measure): number {
+  let position = 0;
+  let max = 0;
+  for (const entry of measure.entries) {
+    if (entry.type === 'note') {
+      if (!entry.chord) {
+        position += entry.duration;
+        if (position > max) max = position;
+      }
+    } else if (entry.type === 'backup') {
+      position -= entry.duration;
+    } else if (entry.type === 'forward') {
+      position += entry.duration;
+      if (position > max) max = position;
+    }
+  }
+  return max;
+}
+
+/**
+ * Absolute tick at the end of a measure, given where it started.
+ * Implicit (pickup) measures use their actual content length; regular
+ * measures use the time signature but never exceed their actual content.
+ */
+function measureEndTick(
+  measure: Measure,
+  part: Part,
+  divisions: number,
+  measureStartTick: number,
+  maxPosition: number,
+  ticksPerQuarterNote: number
+): number {
+  const actualTicks = Math.round((maxPosition * ticksPerQuarterNote) / divisions);
+
+  if (measure.implicit) {
+    return measureStartTick + actualTicks;
+  }
+
+  const timeAttrs = findTimeSignature(part, measure.number);
+  if (timeAttrs) {
+    const measureDuration = (timeAttrs.beats / timeAttrs.beatType) * 4 * divisions;
+    const calculatedTicks = Math.round((measureDuration * ticksPerQuarterNote) / divisions);
+    // Use the smaller of calculated and actual for incomplete measures
+    // (e.g., last measure before a repeat that combines with a pickup).
+    const ticksToAdd = Math.min(calculatedTicks, actualTicks > 0 ? actualTicks : calculatedTicks);
+    return measureStartTick + ticksToAdd;
+  }
+
+  return measureStartTick + actualTicks;
+}
+
+/** Parse a metronome per-minute value to a numeric BPM, or null. */
+function metronomeBpm(perMinute: number | string | undefined): number | null {
+  if (perMinute === undefined) return null;
+  const bpm = typeof perMinute === 'number' ? perMinute : parseFloat(perMinute);
+  return isNaN(bpm) ? null : bpm;
+}
+
+/**
+ * Create conductor track (initial time signature + all tempo changes).
+ *
+ * Tempo is read from three sources, in document order at each position:
+ * metronome direction-types, the <sound tempo> inside a direction, and
+ * standalone <sound tempo> entries. Events are placed at absolute ticks so
+ * that tempo changes inside repeated sections land correctly.
  */
 function createConductorTrack(
   score: Score,
   defaultTempo: number,
-  ticksPerQuarterNote: number
+  ticksPerQuarterNote: number,
+  measureOrder: number[]
 ): Uint8Array {
   const events: number[] = [];
 
-  // Set tempo at the beginning (microseconds per quarter note)
-  const microsecondsPerQuarterNote = Math.round(60000000 / defaultTempo);
-  events.push(
-    ...writeVariableLength(0), // Delta time
-    0xff, 0x51, 0x03, // Tempo meta event
-    (microsecondsPerQuarterNote >> 16) & 0xff,
-    (microsecondsPerQuarterNote >> 8) & 0xff,
-    microsecondsPerQuarterNote & 0xff
-  );
+  // Collect tempo changes as absolute-tick events.
+  const tempoEvents: { tick: number; bpm: number }[] = [];
 
-  // Get initial time signature from first measure
-  if (score.parts.length > 0 && score.parts[0].measures.length > 0) {
-    const firstMeasure = score.parts[0].measures[0];
-    const time = firstMeasure.attributes?.time;
-    if (time) {
-      const numerator = parseInt(time.beats, 10) || 4;
-      const denominator = Math.log2(time.beatType);
-      events.push(
-        ...writeVariableLength(0), // Delta time
-        0xff, 0x58, 0x04, // Time signature meta event
-        numerator,
-        denominator,
-        24, // MIDI clocks per metronome click
-        8   // 32nd notes per 24 MIDI clocks
-      );
-    }
-  }
-
-  // Scan for tempo changes in directions (with repeat expansion)
   if (score.parts.length > 0) {
     const part = score.parts[0];
     let divisions = 1;
-
-    // Expand repeats for conductor track as well
-    const measureOrder = expandRepeats(part.measures);
+    let currentTick = 0;
 
     for (const measureIndex of measureOrder) {
       const measure = part.measures[measureIndex];
+      if (!measure) continue;
       if (measure.attributes?.divisions) {
         divisions = measure.attributes.divisions;
       }
 
-      let measurePosition = 0;
+      const measureStartTick = currentTick;
+      let position = 0;
+      const tickAt = (pos: number) =>
+        measureStartTick + Math.round((pos * ticksPerQuarterNote) / divisions);
 
       for (const entry of measure.entries) {
         if (entry.type === 'direction') {
           for (const dirType of entry.directionTypes) {
             if (dirType.kind === 'metronome') {
-              const bpm = typeof dirType.perMinute === 'number' ? dirType.perMinute : parseInt(String(dirType.perMinute), 10);
-              if (isNaN(bpm)) continue;
-              const usPerQuarter = Math.round(60000000 / bpm);
-              const tickDelta = (measurePosition * ticksPerQuarterNote) / divisions;
-
-              events.push(
-                ...writeVariableLength(Math.round(tickDelta)),
-                0xff, 0x51, 0x03,
-                (usPerQuarter >> 16) & 0xff,
-                (usPerQuarter >> 8) & 0xff,
-                usPerQuarter & 0xff
-              );
-              // currentTick tracked in main track loop
+              const bpm = metronomeBpm(dirType.perMinute);
+              if (bpm !== null) tempoEvents.push({ tick: tickAt(position), bpm });
             }
           }
+          if (entry.sound?.tempo) {
+            tempoEvents.push({ tick: tickAt(position), bpm: entry.sound.tempo });
+          }
+        } else if (entry.type === 'sound') {
+          if (entry.tempo) tempoEvents.push({ tick: tickAt(position), bpm: entry.tempo });
         } else if (entry.type === 'note' && !entry.chord) {
-          measurePosition += entry.duration;
+          position += entry.duration;
         } else if (entry.type === 'backup') {
-          measurePosition -= entry.duration;
+          position -= entry.duration;
         } else if (entry.type === 'forward') {
-          measurePosition += entry.duration;
+          position += entry.duration;
         }
       }
+
+      currentTick = measureEndTick(
+        measure,
+        part,
+        divisions,
+        measureStartTick,
+        measureMaxPosition(measure),
+        ticksPerQuarterNote
+      );
     }
+  }
+
+  // Resolve the starting tempo: an explicit tempo at tick 0 wins, else default.
+  tempoEvents.sort((a, b) => a.tick - b.tick);
+  const startBpm = tempoEvents.length > 0 && tempoEvents[0].tick === 0
+    ? tempoEvents[0].bpm
+    : defaultTempo;
+
+  const pushTempo = (deltaTick: number, bpm: number) => {
+    const usPerQuarter = Math.round(60000000 / bpm);
+    events.push(
+      ...writeVariableLength(deltaTick),
+      0xff, 0x51, 0x03,
+      (usPerQuarter >> 16) & 0xff,
+      (usPerQuarter >> 8) & 0xff,
+      usPerQuarter & 0xff
+    );
+  };
+
+  // Initial tempo at tick 0.
+  pushTempo(0, startBpm);
+
+  // Initial time signature from the first measure.
+  if (score.parts.length > 0 && score.parts[0].measures.length > 0) {
+    const time = score.parts[0].measures[0].attributes?.time;
+    if (time) {
+      const numerator = parseInt(time.beats, 10) || 4;
+      const denominator = Math.log2(time.beatType);
+      events.push(
+        ...writeVariableLength(0),
+        0xff, 0x58, 0x04,
+        numerator,
+        denominator,
+        24,
+        8
+      );
+    }
+  }
+
+  // Remaining tempo changes, as deltas from the previous event.
+  let lastTick = 0;
+  let lastBpm = startBpm;
+  for (const ev of tempoEvents) {
+    if (ev.tick === 0) continue; // already emitted as the initial tempo
+    if (ev.bpm === lastBpm) continue; // no audible change
+    pushTempo(ev.tick - lastTick, ev.bpm);
+    lastTick = ev.tick;
+    lastBpm = ev.bpm;
   }
 
   // End of track
@@ -175,7 +383,8 @@ function createPartTrack(
   channel: number,
   program: number,
   ticksPerQuarterNote: number,
-  defaultVelocity: number
+  defaultVelocity: number,
+  measureOrder: number[]
 ): Uint8Array {
   const events: number[] = [];
 
@@ -187,17 +396,22 @@ function createPartTrack(
   );
 
   // Track note events
-  const noteEvents: { tick: number; type: 'on' | 'off'; note: number; velocity: number }[] = [];
+  const noteEvents: MidiNoteEvent[] = [];
 
   let currentTick = 0;
   let divisions = 1;
   let chromaticTranspose = 0; // Track transposition for transposing instruments
 
-  // Expand repeats to get playback order
-  const measureOrder = expandRepeats(part.measures);
+  // Expressive state carried across measures.
+  let currentVelocity = defaultVelocity; // baseline from dynamics markings
+  let pendingAccent = 1; // sforzando-family accent for the next onset
+  let accentBound = false; // whether pendingAccent is already tied to an onset
+  let pendingGrace: NoteEntry[] = []; // grace notes awaiting their principal
 
   for (const measureIndex of measureOrder) {
     const measure = part.measures[measureIndex];
+    // Parts may differ in length; the order is derived from the first part.
+    if (!measure) continue;
 
     // Update divisions from the original measure (need to track last seen divisions)
     if (measure.attributes?.divisions) {
@@ -217,34 +431,47 @@ function createPartTrack(
       if (entry.type === 'note') {
         const note = entry as NoteEntry;
 
-        if (note.pitch && !note.grace) {
+        // Grace notes carry no duration; defer them until their principal note.
+        if (note.grace) {
+          if (note.pitch) pendingGrace.push(note);
+          continue;
+        }
+
+        // New onset: retire a spent accent and bind a fresh one.
+        if (!note.chord) {
+          if (accentBound) {
+            pendingAccent = 1;
+            accentBound = false;
+          }
+          if (pendingAccent !== 1) accentBound = true;
+        }
+
+        if (note.pitch) {
           const midiNote = pitchToMidiNote(note.pitch, chromaticTranspose);
           // Chord notes use the same position as the previous non-chord note
           const notePosition = note.chord ? chordBasePosition : position;
           const startTick = measureStartTick + Math.round((notePosition * ticksPerQuarterNote) / divisions);
           const durationTicks = Math.round((note.duration * ticksPerQuarterNote) / divisions);
 
+          // Flush any pending grace notes onto this onset (head note only).
+          if (!note.chord && pendingGrace.length > 0) {
+            scheduleGraceNotes(pendingGrace, startTick, currentVelocity, chromaticTranspose, ticksPerQuarterNote, noteEvents);
+            pendingGrace = [];
+          }
+
+          const velocity = clampVelocity(currentVelocity * pendingAccent * articulationVelocityMultiplier(note));
+
           const isTieStop = hasTieStop(note);
           const isTieStart = hasTieStart(note);
 
           // Don't generate note-on for tie continuations (the note is already sounding)
           if (!isTieStop) {
-            noteEvents.push({
-              tick: startTick,
-              type: 'on',
-              note: midiNote,
-              velocity: defaultVelocity,
-            });
+            noteEvents.push({ tick: startTick, type: 'on', note: midiNote, velocity });
           }
 
           // Don't generate note-off for tie starts (the note continues into the next tied note)
           if (!isTieStart) {
-            noteEvents.push({
-              tick: startTick + durationTicks,
-              type: 'off',
-              note: midiNote,
-              velocity: 0,
-            });
+            noteEvents.push({ tick: startTick + durationTicks, type: 'off', note: midiNote, velocity: 0 });
           }
         }
 
@@ -254,6 +481,22 @@ function createPartTrack(
           position += note.duration;
           if (position > maxPosition) {
             maxPosition = position;
+          }
+        }
+      } else if (entry.type === 'direction') {
+        // Dynamics markings update the baseline velocity / accent.
+        for (const dt of entry.directionTypes) {
+          if (dt.kind === 'dynamics' && dt.value) {
+            const abs = DYNAMICS_VELOCITY[dt.value];
+            if (abs !== undefined) {
+              currentVelocity = abs;
+            } else {
+              const accent = SF_ACCENT_MULTIPLIER[dt.value];
+              if (accent !== undefined) {
+                pendingAccent = accent;
+                accentBound = false;
+              }
+            }
           }
         }
       } else if (entry.type === 'backup') {
@@ -266,26 +509,21 @@ function createPartTrack(
       }
     }
 
-    // Move to the end of the measure
-    // For implicit (pickup) measures, use actual content duration
-    // For regular measures, use time signature-based duration
-    if (measure.implicit) {
-      // Implicit measures (pickup/anacrusis) should use actual content length
-      currentTick = measureStartTick + Math.round((maxPosition * ticksPerQuarterNote) / divisions);
-    } else {
-      const timeAttrs = findTimeSignature(part, measure.number);
-      if (timeAttrs) {
-        const measureDuration = (timeAttrs.beats / timeAttrs.beatType) * 4 * divisions;
-        const calculatedTicks = Math.round((measureDuration * ticksPerQuarterNote) / divisions);
-        const actualTicks = Math.round((maxPosition * ticksPerQuarterNote) / divisions);
-        // Use the smaller of calculated and actual for incomplete measures
-        // (e.g., last measure before repeat that combines with pickup)
-        const ticksToAdd = Math.min(calculatedTicks, actualTicks > 0 ? actualTicks : calculatedTicks);
-        currentTick = measureStartTick + ticksToAdd;
-      } else {
-        currentTick = measureStartTick + Math.round((maxPosition * ticksPerQuarterNote) / divisions);
-      }
-    }
+    currentTick = measureEndTick(
+      measure,
+      part,
+      divisions,
+      measureStartTick,
+      maxPosition,
+      ticksPerQuarterNote
+    );
+  }
+
+  // Any grace notes left unattached (e.g. trailing the final note) play just
+  // before the end of the part.
+  if (pendingGrace.length > 0) {
+    scheduleGraceNotes(pendingGrace, currentTick, currentVelocity, chromaticTranspose, ticksPerQuarterNote, noteEvents);
+    pendingGrace = [];
   }
 
   // Safety: ensure every note-on has a matching note-off.
@@ -362,84 +600,6 @@ function findTimeSignature(
   }
 
   return time;
-}
-
-/**
- * Check if a measure has a forward repeat at the start
- */
-function hasForwardRepeat(measure: Measure): boolean {
-  if (!measure.barlines) return false;
-  return measure.barlines.some(
-    (b) => b.location === 'left' && b.repeat?.direction === 'forward'
-  );
-}
-
-/**
- * Check if a measure has a backward repeat at the end
- */
-function hasBackwardRepeat(measure: Measure): { found: boolean; times: number } {
-  if (!measure.barlines) return { found: false, times: 2 };
-  const barline = measure.barlines.find(
-    (b) => b.location === 'right' && b.repeat?.direction === 'backward'
-  );
-  if (barline?.repeat) {
-    return { found: true, times: barline.repeat.times ?? 2 };
-  }
-  return { found: false, times: 2 };
-}
-
-/**
- * Expand repeats and return an array of measure indices in playback order
- */
-function expandRepeats(measures: Measure[]): number[] {
-  const result: number[] = [];
-  let i = 0;
-
-  while (i < measures.length) {
-    // Find if there's a backward repeat ahead
-    let backwardRepeatIndex = -1;
-    let repeatTimes = 2;
-
-    for (let j = i; j < measures.length; j++) {
-      const backwardInfo = hasBackwardRepeat(measures[j]);
-      if (backwardInfo.found) {
-        backwardRepeatIndex = j;
-        repeatTimes = backwardInfo.times;
-        break;
-      }
-      // Stop searching if we hit another forward repeat (nested repeats)
-      if (j > i && hasForwardRepeat(measures[j])) {
-        break;
-      }
-    }
-
-    if (backwardRepeatIndex >= 0) {
-      // Find the matching forward repeat (or start of piece)
-      let forwardRepeatIndex = 0;
-      for (let j = i; j <= backwardRepeatIndex; j++) {
-        if (hasForwardRepeat(measures[j])) {
-          forwardRepeatIndex = j;
-          break;
-        }
-      }
-
-      // Play through the repeat section 'times' times
-      for (let rep = 0; rep < repeatTimes; rep++) {
-        for (let j = forwardRepeatIndex; j <= backwardRepeatIndex; j++) {
-          result.push(j);
-        }
-      }
-
-      // Continue after the repeat
-      i = backwardRepeatIndex + 1;
-    } else {
-      // No repeat, just add this measure
-      result.push(i);
-      i++;
-    }
-  }
-
-  return result;
 }
 
 /**

--- a/src/exporters/midi.ts
+++ b/src/exporters/midi.ts
@@ -198,7 +198,9 @@ function measureMaxPosition(measure: Measure): number {
   let max = 0;
   for (const entry of measure.entries) {
     if (entry.type === 'note') {
-      if (!entry.chord) {
+      // Grace notes carry no time and must not advance the position
+      // (mirrors the part-track loop, which skips them entirely).
+      if (!entry.chord && !entry.grace) {
         position += entry.duration;
         if (position > max) max = position;
       }
@@ -646,34 +648,33 @@ function writeUint16BE(value: number): number[] {
  * Build the complete MIDI file
  */
 function buildMidiFile(tracks: Uint8Array[], ticksPerQuarterNote: number): Uint8Array {
-  const chunks: number[] = [];
+  // Header chunk: "MThd" + length(6) + format(1) + numTracks + division.
+  const header = Uint8Array.from([
+    0x4d, 0x54, 0x68, 0x64,
+    ...writeUint32BE(6),
+    ...writeUint16BE(1),
+    ...writeUint16BE(tracks.length),
+    ...writeUint16BE(ticksPerQuarterNote),
+  ]);
 
-  // Header chunk
-  const headerChunkType = [0x4d, 0x54, 0x68, 0x64]; // "MThd"
-  const headerLength = writeUint32BE(6);
-  const format = writeUint16BE(1); // Type 1 MIDI file
-  const numTracks = writeUint16BE(tracks.length);
-  const division = writeUint16BE(ticksPerQuarterNote);
+  // Total size up front so we can write into one buffer (no large spreads,
+  // which would risk a stack overflow on big repeat-expanded tracks).
+  let total = header.length;
+  for (const track of tracks) total += 8 + track.length;
 
-  chunks.push(
-    ...headerChunkType,
-    ...headerLength,
-    ...format,
-    ...numTracks,
-    ...division
-  );
+  const out = new Uint8Array(total);
+  let offset = 0;
+  out.set(header, offset);
+  offset += header.length;
 
-  // Track chunks
   for (const track of tracks) {
-    const trackChunkType = [0x4d, 0x54, 0x72, 0x6b]; // "MTrk"
-    const trackLength = writeUint32BE(track.length);
-
-    chunks.push(
-      ...trackChunkType,
-      ...trackLength,
-      ...Array.from(track)
-    );
+    out.set([0x4d, 0x54, 0x72, 0x6b], offset); // "MTrk"
+    offset += 4;
+    out.set(writeUint32BE(track.length), offset);
+    offset += 4;
+    out.set(track, offset);
+    offset += track.length;
   }
 
-  return new Uint8Array(chunks);
+  return out;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,10 @@ export {
   getRepeatStructure,
   findBarlines,
   getEndings,
+  // Playback sequence (repeat / volta / jump expansion)
+  generatePlaybackSequence,
+  extractPlaybackControls,
+  hasPlaybackControls,
   getKeyChanges,
   getTimeChanges,
   getClefChanges,
@@ -169,7 +173,7 @@ export {
   countNotes,
   scoresEqual,
 } from './query';
-export type { VoiceFilter, NormalizedPositionOptions, PitchRange, FindNotesFilter, RoundtripMetrics } from './query';
+export type { VoiceFilter, NormalizedPositionOptions, PitchRange, FindNotesFilter, RoundtripMetrics, PlaybackMeasure, PlaybackControls } from './query';
 
 // Operations (re-export for convenience)
 export {

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -52,6 +52,14 @@ import { getAbsolutePositionForNote, createPositionState, updatePositionForEntry
 /**
  * Filter options for voice/staff selection
  */
+// Playback sequence (repeat / volta / jump expansion)
+export {
+  generatePlaybackSequence,
+  extractPlaybackControls,
+  hasPlaybackControls,
+} from './playback-sequence';
+export type { PlaybackMeasure, PlaybackControls } from './playback-sequence';
+
 export interface VoiceFilter {
   voice?: string;
   staff?: number;

--- a/src/query/playback-sequence.ts
+++ b/src/query/playback-sequence.ts
@@ -1,0 +1,541 @@
+/**
+ * Playback Sequence Generator
+ *
+ * Analyzes repeat structures, voltas (endings), and jump instructions
+ * (D.C., D.S., Coda, Segno, Fine, To Coda) in a score to produce the
+ * correct playback order of measures.
+ *
+ * This is the structural expansion that turns the written score into the
+ * order a performer would actually play it. The MIDI exporter consumes
+ * this so that repeats, 1st/2nd endings, and da capo / dal segno jumps are
+ * reflected in the rendered audio.
+ *
+ * The algorithm is ported from the validated playback engine in the
+ * Octava project and adapted to the typed musicxml-io Score model.
+ */
+
+import type { Score, Part, DirectionEntry, SoundEntry } from '../types';
+
+/**
+ * Volta (ending bracket) information
+ */
+interface VoltaInfo {
+  measureIndex: number;
+  numbers: number[]; // e.g., [1] for "1", [1, 2] for "1, 2"
+  type: 'start' | 'stop' | 'discontinue';
+}
+
+/**
+ * Jump instruction information
+ */
+interface JumpInfo {
+  measureIndex: number;
+  type: 'dc' | 'dc_al_fine' | 'dc_al_coda' | 'ds' | 'ds_al_fine' | 'ds_al_coda';
+}
+
+/**
+ * Parsed playback control structures from a score
+ */
+export interface PlaybackControls {
+  /** measure indices that carry a forward repeat (||:) */
+  repeatStarts: number[];
+  /** backward repeats (:||) with their repeat counts */
+  repeatEnds: { measureIndex: number; times: number }[];
+  /** volta brackets in document order */
+  voltas: VoltaInfo[];
+  /** jump instructions (D.C., D.S., and their al fine/al coda variants) */
+  jumps: JumpInfo[];
+  /** measure index of the segno symbol */
+  segnoIndex: number | null;
+  /** measure index of the coda symbol */
+  codaIndex: number | null;
+  /** measure index of the Fine marking */
+  fineIndex: number | null;
+  /** measure index of the "To Coda" marking */
+  toCodaIndex: number | null;
+}
+
+/**
+ * A measure to play, with the repeat-iteration context it was reached in.
+ */
+export interface PlaybackMeasure {
+  /** Index of the measure in the original (written) score */
+  measureIndex: number;
+  /** Which repeat iteration produced this entry (1-based; 0 = not in a repeat) */
+  repeatIteration: number;
+}
+
+/**
+ * Parse an ending number string into an array of iteration numbers.
+ * e.g. "1" -> [1], "1, 2" -> [1, 2], "1-3" -> [1, 2, 3]
+ */
+function parseEndingNumbers(numberStr: string): number[] {
+  const numbers: number[] = [];
+  const parts = numberStr.split(/[,\s]+/);
+
+  for (const part of parts) {
+    if (part.includes('-')) {
+      const [start, end] = part.split('-').map((s) => parseInt(s.trim(), 10));
+      if (!isNaN(start) && !isNaN(end)) {
+        for (let i = start; i <= end; i++) {
+          numbers.push(i);
+        }
+      }
+    } else {
+      const num = parseInt(part.trim(), 10);
+      if (!isNaN(num)) {
+        numbers.push(num);
+      }
+    }
+  }
+
+  return numbers.length > 0 ? numbers : [1];
+}
+
+/**
+ * Jump-instruction text classification.
+ * Returns the structural jump type, or one of the location markers
+ * ('fine' | 'to_coda' | 'coda' | 'segno') that text can also denote.
+ */
+type TextJumpType = JumpInfo['type'] | 'fine' | 'to_coda' | 'coda' | 'segno';
+
+/**
+ * Parse jump-instruction text (e.g. "D.C. al Fine") into a structural type.
+ */
+function parseJumpText(text: string): TextJumpType | null {
+  const t = text.toLowerCase().replace(/\s+/g, ' ').trim();
+
+  if (t.includes('d.c. al coda') || t.includes('da capo al coda')) return 'dc_al_coda';
+  if (t.includes('d.c. al fine') || t.includes('da capo al fine')) return 'dc_al_fine';
+  if (t.includes('d.c.') || t.includes('da capo')) return 'dc';
+  if (t.includes('d.s. al coda') || t.includes('dal segno al coda')) return 'ds_al_coda';
+  if (t.includes('d.s. al fine') || t.includes('dal segno al fine')) return 'ds_al_fine';
+  if (t.includes('d.s.') || t.includes('dal segno')) return 'ds';
+  if (t === 'fine') return 'fine';
+  if (t.includes('to coda') || t.includes('al coda')) return 'to_coda';
+  if (t === 'coda' || t === '\u{1D14C}') return 'coda';
+  if (t === 'segno' || t === '\u{1D10B}') return 'segno';
+
+  return null;
+}
+
+/**
+ * Get the first <words> text from a direction entry, if any.
+ */
+function getFirstWordsText(entry: DirectionEntry): string | undefined {
+  for (const dt of entry.directionTypes) {
+    if (dt.kind === 'words' && dt.text) return dt.text;
+  }
+  return undefined;
+}
+
+function hasDirectionKind(entry: DirectionEntry, kind: 'segno' | 'coda'): boolean {
+  return entry.directionTypes.some((dt) => dt.kind === kind);
+}
+
+/**
+ * Extract repeat / volta / jump control structures from the structural part.
+ *
+ * Repeats and voltas apply to the whole system, so by convention we scan a
+ * single part (the first by default). Jump instructions and segno/coda/fine
+ * markers are read from both <direction> entries (words text + segno/coda
+ * symbols) and standalone <sound> entries.
+ */
+export function extractPlaybackControls(part: Part): PlaybackControls {
+  const controls: PlaybackControls = {
+    repeatStarts: [],
+    repeatEnds: [],
+    voltas: [],
+    jumps: [],
+    segnoIndex: null,
+    codaIndex: null,
+    fineIndex: null,
+    toCodaIndex: null,
+  };
+
+  // Raw sound-based jumps deferred until after the full scan, so that
+  // al fine / al coda can be resolved against discovered Fine/Coda markers.
+  const soundJumps: { measureIndex: number; base: 'dc' | 'ds' }[] = [];
+
+  for (let measureIndex = 0; measureIndex < part.measures.length; measureIndex++) {
+    const measure = part.measures[measureIndex];
+
+    // --- Barlines: repeats and voltas ---
+    if (measure.barlines) {
+      for (const barline of measure.barlines) {
+        if (barline.repeat) {
+          if (barline.repeat.direction === 'forward') {
+            controls.repeatStarts.push(measureIndex);
+          } else if (barline.repeat.direction === 'backward') {
+            controls.repeatEnds.push({
+              measureIndex,
+              times: barline.repeat.times ?? 2,
+            });
+          }
+        }
+
+        if (barline.ending) {
+          const numbers = parseEndingNumbers(barline.ending.number);
+          controls.voltas.push({
+            measureIndex,
+            numbers,
+            type: barline.ending.type,
+          });
+        }
+      }
+    }
+
+    // --- Entries: directions (words / segno / coda) and sounds ---
+    for (const entry of measure.entries) {
+      if (entry.type === 'direction') {
+        const dir = entry as DirectionEntry;
+
+        if (hasDirectionKind(dir, 'segno') && controls.segnoIndex === null) {
+          controls.segnoIndex = measureIndex;
+        }
+        if (hasDirectionKind(dir, 'coda') && controls.codaIndex === null) {
+          controls.codaIndex = measureIndex;
+        }
+
+        const words = getFirstWordsText(dir);
+        if (words) {
+          const jt = parseJumpText(words);
+          if (jt === 'fine') {
+            if (controls.fineIndex === null) controls.fineIndex = measureIndex;
+          } else if (jt === 'to_coda') {
+            if (controls.toCodaIndex === null) controls.toCodaIndex = measureIndex;
+          } else if (jt === 'coda') {
+            if (controls.codaIndex === null) controls.codaIndex = measureIndex;
+          } else if (jt === 'segno') {
+            if (controls.segnoIndex === null) controls.segnoIndex = measureIndex;
+          } else if (jt) {
+            controls.jumps.push({ measureIndex, type: jt });
+          }
+        }
+      } else if (entry.type === 'sound') {
+        const sound = entry as SoundEntry;
+        if (sound.segno && controls.segnoIndex === null) controls.segnoIndex = measureIndex;
+        if (sound.coda && controls.codaIndex === null) controls.codaIndex = measureIndex;
+        if (sound.tocoda && controls.toCodaIndex === null) controls.toCodaIndex = measureIndex;
+        if (sound.fine && controls.fineIndex === null) controls.fineIndex = measureIndex;
+        if (sound.dacapo) soundJumps.push({ measureIndex, base: 'dc' });
+        if (sound.dalsegno) soundJumps.push({ measureIndex, base: 'ds' });
+      }
+    }
+  }
+
+  // Resolve sound-based jumps now that Fine / To Coda markers are known.
+  // Only add them if a words-based jump was not already recorded for the
+  // same measure (words take precedence as the more explicit source).
+  for (const sj of soundJumps) {
+    if (controls.jumps.some((j) => j.measureIndex === sj.measureIndex)) continue;
+    let type: JumpInfo['type'];
+    if (controls.fineIndex !== null) {
+      type = sj.base === 'dc' ? 'dc_al_fine' : 'ds_al_fine';
+    } else if (controls.toCodaIndex !== null || controls.codaIndex !== null) {
+      type = sj.base === 'dc' ? 'dc_al_coda' : 'ds_al_coda';
+    } else {
+      type = sj.base;
+    }
+    controls.jumps.push({ measureIndex: sj.measureIndex, type });
+  }
+
+  return controls;
+}
+
+/**
+ * Build a map from measure index to the volta iteration numbers that play it.
+ */
+function buildVoltaRanges(voltas: VoltaInfo[], measureCount: number): Map<number, number[]> {
+  const voltaRanges = new Map<number, number[]>();
+
+  let currentVoltaStart: number | null = null;
+  let currentVoltaNumbers: number[] = [];
+
+  for (const volta of voltas) {
+    if (volta.type === 'start') {
+      currentVoltaStart = volta.measureIndex;
+      currentVoltaNumbers = volta.numbers;
+    } else if ((volta.type === 'stop' || volta.type === 'discontinue') && currentVoltaStart !== null) {
+      for (let i = currentVoltaStart; i <= volta.measureIndex; i++) {
+        voltaRanges.set(i, currentVoltaNumbers);
+      }
+      currentVoltaStart = null;
+    }
+  }
+
+  // Unclosed volta extends to the end of the score.
+  if (currentVoltaStart !== null) {
+    for (let i = currentVoltaStart; i < measureCount; i++) {
+      voltaRanges.set(i, currentVoltaNumbers);
+    }
+  }
+
+  return voltaRanges;
+}
+
+/**
+ * Generate the playback sequence: the list of measures in the order they
+ * should be performed, with repeats expanded and voltas / jumps resolved.
+ *
+ * @param score - the score to analyze
+ * @param options.partIndex - which part to read structure from (default: 0)
+ */
+export function generatePlaybackSequence(
+  score: Score,
+  options?: { partIndex?: number }
+): PlaybackMeasure[] {
+  const partIndex = options?.partIndex ?? 0;
+  const part = score.parts[partIndex];
+  if (!part) return [];
+
+  const measureCount = part.measures.length;
+  const sequence: PlaybackMeasure[] = [];
+  if (measureCount === 0) return sequence;
+
+  const controls = extractPlaybackControls(part);
+
+  // Fast path: nothing structural, play straight through.
+  if (
+    controls.repeatStarts.length === 0 &&
+    controls.repeatEnds.length === 0 &&
+    controls.voltas.length === 0 &&
+    controls.jumps.length === 0
+  ) {
+    for (let i = 0; i < measureCount; i++) {
+      sequence.push({ measureIndex: i, repeatIteration: 0 });
+    }
+    return sequence;
+  }
+
+  const voltaRanges = buildVoltaRanges(controls.voltas, measureCount);
+
+  const sortedRepeatStarts = [...controls.repeatStarts].sort((a, b) => a - b);
+  const sortedRepeatEnds = [...controls.repeatEnds].sort((a, b) => a.measureIndex - b.measureIndex);
+
+  // For each repeat end, find its matching forward repeat (or the measure
+  // after the previous repeat section if none is marked).
+  const repeatSections = new Map<number, { startIndex: number; times: number }>();
+  const voltaToRepeatEnd = new Map<number, number>();
+  const usedRepeatStarts = new Set<number>();
+
+  let lastRepeatEndMeasure = -1;
+  for (const repeatEnd of sortedRepeatEnds) {
+    let startIndex: number | null = null;
+    for (const startMeasure of sortedRepeatStarts) {
+      if (
+        startMeasure <= repeatEnd.measureIndex &&
+        startMeasure > lastRepeatEndMeasure &&
+        !usedRepeatStarts.has(startMeasure)
+      ) {
+        startIndex = startMeasure;
+      } else if (startMeasure > repeatEnd.measureIndex) {
+        break;
+      }
+    }
+
+    if (startIndex === null) {
+      startIndex = lastRepeatEndMeasure + 1;
+    } else {
+      usedRepeatStarts.add(startIndex);
+    }
+
+    repeatSections.set(repeatEnd.measureIndex, {
+      startIndex,
+      times: repeatEnd.times,
+    });
+
+    lastRepeatEndMeasure = repeatEnd.measureIndex;
+
+    // Associate volta measures with this repeat section (inside it, or
+    // immediately following the repeat end for 2nd/3rd endings).
+    voltaRanges.forEach((_iterations, voltaMeasure) => {
+      const isInsideRepeat = voltaMeasure >= startIndex! && voltaMeasure <= repeatEnd.measureIndex;
+      const isImmediatelyAfter =
+        voltaMeasure > repeatEnd.measureIndex && !voltaToRepeatEnd.has(voltaMeasure);
+
+      if (isInsideRepeat) {
+        voltaToRepeatEnd.set(voltaMeasure, repeatEnd.measureIndex);
+      } else if (isImmediatelyAfter) {
+        let belongsToLaterRepeat = false;
+        for (const otherEnd of sortedRepeatEnds) {
+          if (otherEnd.measureIndex > repeatEnd.measureIndex) {
+            const otherSection = repeatSections.get(otherEnd.measureIndex);
+            if (
+              otherSection &&
+              voltaMeasure >= otherSection.startIndex &&
+              voltaMeasure <= otherEnd.measureIndex
+            ) {
+              belongsToLaterRepeat = true;
+              break;
+            }
+          }
+        }
+        if (!belongsToLaterRepeat) {
+          voltaToRepeatEnd.set(voltaMeasure, repeatEnd.measureIndex);
+        }
+      }
+    });
+  }
+
+  // --- Traversal state machine ---
+  let currentMeasure = 0;
+  const repeatCounts = new Map<number, number>(); // repeatEndIndex -> current iteration
+  let lastRepeatEndIndex: number | null = null;
+  let lastRepeatIteration = 0;
+  let inRepeatJump = false; // a D.C./D.S. jump has already been taken
+  let stopAtFine = false;
+  let jumpToCoda = false;
+
+  const maxIterations = measureCount * 10 + 10;
+  let iterations = 0;
+
+  while (currentMeasure < measureCount && iterations < maxIterations) {
+    iterations++;
+
+    const voltaIterations = voltaRanges.get(currentMeasure);
+
+    // Determine repeat-iteration context for the current measure.
+    let repeatIteration = 0;
+    let inRepeatSection = false;
+    let currentRepeatEndIndex: number | null = null;
+
+    for (const [endIndex, section] of repeatSections) {
+      if (currentMeasure >= section.startIndex && currentMeasure <= endIndex) {
+        inRepeatSection = true;
+        currentRepeatEndIndex = endIndex;
+        repeatIteration = repeatCounts.get(endIndex) || 1;
+        break;
+      }
+    }
+
+    if (inRepeatSection && currentRepeatEndIndex !== null) {
+      lastRepeatEndIndex = currentRepeatEndIndex;
+      lastRepeatIteration = repeatIteration;
+    }
+
+    // Skip volta measures that do not belong to the current iteration.
+    if (voltaIterations) {
+      let effectiveIteration = repeatIteration;
+      if (!inRepeatSection) {
+        const associatedRepeatEnd = voltaToRepeatEnd.get(currentMeasure);
+        if (associatedRepeatEnd !== undefined) {
+          effectiveIteration = repeatCounts.get(associatedRepeatEnd) || 1;
+        } else if (lastRepeatEndIndex !== null) {
+          effectiveIteration = lastRepeatIteration;
+        }
+      }
+
+      if (!voltaIterations.includes(effectiveIteration)) {
+        currentMeasure++;
+        continue;
+      }
+    }
+
+    sequence.push({
+      measureIndex: currentMeasure,
+      repeatIteration: inRepeatSection ? repeatIteration : 0,
+    });
+
+    // Stop at Fine when in a D.C./D.S. al Fine pass.
+    if (stopAtFine && controls.fineIndex === currentMeasure) {
+      break;
+    }
+
+    // "To Coda" jump (after playing this measure).
+    if (jumpToCoda && controls.toCodaIndex === currentMeasure && controls.codaIndex !== null) {
+      currentMeasure = controls.codaIndex;
+      jumpToCoda = false;
+      continue;
+    }
+
+    // Repeat end inside a marked repeat section.
+    const repeatSection = repeatSections.get(currentMeasure);
+    if (repeatSection) {
+      const currentCount = repeatCounts.get(currentMeasure) || 1;
+      if (currentCount < repeatSection.times) {
+        repeatCounts.set(currentMeasure, currentCount + 1);
+        currentMeasure = repeatSection.startIndex;
+        continue;
+      }
+    }
+
+    // Volta brackets sitting after the repeat end barline (2nd/3rd endings).
+    if (voltaIterations && !inRepeatSection) {
+      const associatedRepeatEnd = voltaToRepeatEnd.get(currentMeasure);
+      if (associatedRepeatEnd !== undefined) {
+        const repeatSectionForVolta = repeatSections.get(associatedRepeatEnd);
+        if (repeatSectionForVolta) {
+          const currentCount = repeatCounts.get(associatedRepeatEnd) || 1;
+          if (currentCount < repeatSectionForVolta.times) {
+            repeatCounts.set(associatedRepeatEnd, currentCount + 1);
+            currentMeasure = repeatSectionForVolta.startIndex;
+            continue;
+          }
+        }
+      }
+    }
+
+    // Jump instructions (D.C. / D.S. family). Only the first one is taken.
+    const jumpAtMeasure = controls.jumps.find((j) => j.measureIndex === currentMeasure);
+    if (jumpAtMeasure && !inRepeatJump) {
+      inRepeatJump = true;
+
+      switch (jumpAtMeasure.type) {
+        case 'dc':
+          currentMeasure = 0;
+          continue;
+        case 'dc_al_fine':
+          currentMeasure = 0;
+          stopAtFine = true;
+          continue;
+        case 'dc_al_coda':
+          currentMeasure = 0;
+          jumpToCoda = true;
+          continue;
+        case 'ds':
+          if (controls.segnoIndex !== null) {
+            currentMeasure = controls.segnoIndex;
+            continue;
+          }
+          break;
+        case 'ds_al_fine':
+          if (controls.segnoIndex !== null) {
+            currentMeasure = controls.segnoIndex;
+            stopAtFine = true;
+            continue;
+          }
+          break;
+        case 'ds_al_coda':
+          if (controls.segnoIndex !== null) {
+            currentMeasure = controls.segnoIndex;
+            jumpToCoda = true;
+            continue;
+          }
+          break;
+      }
+    }
+
+    currentMeasure++;
+  }
+
+  return sequence;
+}
+
+/**
+ * Whether a score contains any repeat / volta / jump structures that would
+ * make its playback order differ from its written order.
+ */
+export function hasPlaybackControls(score: Score, options?: { partIndex?: number }): boolean {
+  const part = score.parts[options?.partIndex ?? 0];
+  if (!part) return false;
+  const controls = extractPlaybackControls(part);
+  return (
+    controls.repeatStarts.length > 0 ||
+    controls.repeatEnds.length > 0 ||
+    controls.voltas.length > 0 ||
+    controls.jumps.length > 0 ||
+    controls.segnoIndex !== null ||
+    controls.codaIndex !== null
+  );
+}

--- a/tests/midi-expression.test.ts
+++ b/tests/midi-expression.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  Score,
+  Measure,
+  NoteEntry,
+  DirectionEntry,
+  SoundEntry,
+  DynamicsValue,
+  ArticulationType,
+} from '../src/types';
+import { exportMidi } from '../src/exporters';
+
+let idCounter = 0;
+const id = () => `idx-${idCounter++}`;
+
+// ---- Score builders -------------------------------------------------------
+
+function note(opts: { step?: string; octave?: number; duration?: number; chord?: boolean; grace?: boolean; articulation?: ArticulationType } = {}): NoteEntry {
+  const n: NoteEntry = {
+    _id: id(),
+    type: 'note',
+    pitch: { step: (opts.step ?? 'C') as any, octave: opts.octave ?? 4 },
+    duration: opts.duration ?? 4,
+    voice: '1',
+  };
+  if (opts.chord) n.chord = true;
+  if (opts.grace) {
+    n.grace = {};
+    n.duration = 0;
+  }
+  if (opts.articulation) {
+    n.notations = [{ type: 'articulation', articulation: opts.articulation }];
+  }
+  return n;
+}
+
+function dynamicsDir(value: DynamicsValue): DirectionEntry {
+  return { _id: id(), type: 'direction', directionTypes: [{ kind: 'dynamics', value }] };
+}
+
+function metronomeDir(perMinute: number): DirectionEntry {
+  return {
+    _id: id(),
+    type: 'direction',
+    directionTypes: [{ kind: 'metronome', beatUnit: 'quarter', perMinute }],
+  };
+}
+
+function soundTempoDir(tempo: number): DirectionEntry {
+  return { _id: id(), type: 'direction', directionTypes: [], sound: { tempo } };
+}
+
+function soundTempo(tempo: number): SoundEntry {
+  return { _id: id(), type: 'sound', tempo };
+}
+
+function measure(num: number, entries: Measure['entries']): Measure {
+  return { _id: id(), number: String(num), entries };
+}
+
+function scoreOf(measures: Measure[]): Score {
+  return {
+    _id: id(),
+    metadata: {},
+    partList: [{ type: 'score-part', _id: id(), id: 'P1' }],
+    parts: [{ _id: id(), id: 'P1', measures }],
+  } as Score;
+}
+
+// ---- MIDI parser ----------------------------------------------------------
+
+interface TrackEvents {
+  noteOns: { tick: number; note: number; velocity: number }[];
+  tempos: { tick: number; usPerQuarter: number }[];
+}
+
+function parseMidi(data: Uint8Array): TrackEvents[] {
+  const tracks: TrackEvents[] = [];
+  let pos = 14; // skip 14-byte MThd
+
+  const u32 = (p: number) =>
+    (data[p] << 24) | (data[p + 1] << 16) | (data[p + 2] << 8) | data[p + 3];
+
+  while (pos < data.length) {
+    // 'MTrk'
+    const len = u32(pos + 4);
+    const bodyStart = pos + 8;
+    const bodyEnd = bodyStart + len;
+
+    const ev: TrackEvents = { noteOns: [], tempos: [] };
+    let i = bodyStart;
+    let tick = 0;
+    let runningStatus = 0;
+
+    const readVarLen = () => {
+      let value = 0;
+      for (;;) {
+        const byte = data[i++];
+        value = (value << 7) | (byte & 0x7f);
+        if (!(byte & 0x80)) break;
+      }
+      return value;
+    };
+
+    while (i < bodyEnd) {
+      tick += readVarLen();
+      let status = data[i];
+      if (status & 0x80) {
+        i++;
+        runningStatus = status;
+      } else {
+        status = runningStatus;
+      }
+
+      const hi = status & 0xf0;
+      if (status === 0xff) {
+        const metaType = data[i++];
+        const metaLen = readVarLen();
+        if (metaType === 0x51 && metaLen === 3) {
+          const us = (data[i] << 16) | (data[i + 1] << 8) | data[i + 2];
+          ev.tempos.push({ tick, usPerQuarter: us });
+        }
+        i += metaLen;
+      } else if (hi === 0x90) {
+        const n = data[i++];
+        const v = data[i++];
+        if (v > 0) ev.noteOns.push({ tick, note: n, velocity: v });
+      } else if (hi === 0x80) {
+        i += 2;
+      } else if (hi === 0xc0 || hi === 0xd0) {
+        i += 1;
+      } else {
+        i += 2;
+      }
+    }
+
+    tracks.push(ev);
+    pos = bodyEnd;
+  }
+
+  return tracks;
+}
+
+const bpmToUs = (bpm: number) => Math.round(60000000 / bpm);
+
+// ---- Tests ----------------------------------------------------------------
+
+describe('MIDI velocity from dynamics', () => {
+  it('uses the default velocity when no dynamics are present', () => {
+    const data = exportMidi(scoreOf([measure(1, [note()])]));
+    const part = parseMidi(data)[1];
+    expect(part.noteOns[0].velocity).toBe(80);
+  });
+
+  it('maps dynamic markings to velocity and persists them', () => {
+    const measures = [
+      measure(1, [dynamicsDir('p'), note()]),
+      measure(2, [note()]), // p still in effect
+      measure(3, [dynamicsDir('ff'), note()]),
+    ];
+    const part = parseMidi(exportMidi(scoreOf(measures)))[1];
+    expect(part.noteOns.map((n) => n.velocity)).toEqual([50, 50, 105]);
+  });
+
+  it('applies accent articulation as a velocity multiplier', () => {
+    const measures = [
+      measure(1, [dynamicsDir('mf'), note(), note({ step: 'D', articulation: 'accent' })]),
+    ];
+    const part = parseMidi(exportMidi(scoreOf(measures)))[1];
+    // mf = 75; accent x1.25 -> 94
+    expect(part.noteOns[0].velocity).toBe(75);
+    expect(part.noteOns[1].velocity).toBe(Math.round(75 * 1.25));
+  });
+
+  it('applies a sforzando as a one-shot relative accent', () => {
+    const measures = [
+      measure(1, [dynamicsDir('p'), note(), dynamicsDir('sf'), note({ step: 'D' }), note({ step: 'E' })]),
+    ];
+    const part = parseMidi(exportMidi(scoreOf(measures)))[1];
+    // p=50; sf x1.3 on the next onset only, then back to 50
+    expect(part.noteOns.map((n) => n.velocity)).toEqual([50, Math.round(50 * 1.3), 50]);
+  });
+});
+
+describe('MIDI grace notes', () => {
+  // divisions defaults to 1, so a duration-4 note is one quarter = 480 ticks.
+  it('schedules a grace note before its principal, slightly softer', () => {
+    const measures = [
+      measure(1, [
+        dynamicsDir('mf'),
+        note({ step: 'C', octave: 4 }), // beat 1, ends at tick 1920
+        note({ step: 'D', grace: true, octave: 5 }), // grace before beat 2
+        note({ step: 'E', octave: 4 }), // beat 2 principal at tick 1920
+      ]),
+    ];
+    const part = parseMidi(exportMidi(scoreOf(measures)))[1];
+    expect(part.noteOns.length).toBe(3);
+
+    const grace = part.noteOns.find((n) => n.note === 74)!; // D5
+    const principal = part.noteOns.find((n) => n.note === 64)!; // E4
+    expect(grace).toBeDefined();
+    // Grace comes strictly before the principal's onset
+    expect(grace.tick).toBeLessThan(principal.tick);
+    expect(principal.tick).toBe(1920);
+    // Grace is softer than the mf principal (75)
+    expect(principal.velocity).toBe(75);
+    expect(grace.velocity).toBe(Math.round(75 * 0.85));
+  });
+
+  it('stacks multiple grace notes in order before the beat', () => {
+    const measures = [
+      measure(1, [
+        note({ step: 'C', octave: 4 }), // beat 1 -> tick 0
+        note({ step: 'C', grace: true, octave: 5 }),
+        note({ step: 'D', grace: true, octave: 5 }),
+        note({ step: 'E', octave: 4 }), // beat 2 -> tick 1920
+      ]),
+    ];
+    const part = parseMidi(exportMidi(scoreOf(measures)))[1];
+    expect(part.noteOns.length).toBe(4);
+
+    const c5 = part.noteOns.find((n) => n.note === 72)!;
+    const d5 = part.noteOns.find((n) => n.note === 74)!;
+    const principal = part.noteOns.find((n) => n.note === 64)!;
+    // grace C5 then grace D5 then principal E4, strictly increasing
+    expect(c5.tick).toBeLessThan(d5.tick);
+    expect(d5.tick).toBeLessThan(principal.tick);
+    expect(principal.tick).toBe(1920);
+  });
+});
+
+describe('MIDI tempo sources', () => {
+  it('reads tempo from a metronome direction', () => {
+    const measures = [measure(1, [metronomeDir(90), note()])];
+    const tempos = parseMidi(exportMidi(scoreOf(measures)))[0].tempos;
+    // initial default (120) at tick 0, then 90 once we reach the marking
+    expect(tempos.some((t) => t.usPerQuarter === bpmToUs(90))).toBe(true);
+  });
+
+  it('reads tempo from a <sound tempo> inside a direction', () => {
+    const measures = [measure(1, [soundTempoDir(100), note()])];
+    const tempos = parseMidi(exportMidi(scoreOf(measures)))[0].tempos;
+    expect(tempos[0].usPerQuarter).toBe(bpmToUs(100)); // tempo at tick 0 becomes the initial tempo
+    expect(tempos[0].tick).toBe(0);
+  });
+
+  it('reads tempo from a standalone <sound> entry', () => {
+    const measures = [
+      measure(1, [note()]),
+      measure(2, [soundTempo(60), note()]),
+    ];
+    const tempos = parseMidi(exportMidi(scoreOf(measures)))[0].tempos;
+    // default at 0, then 60 at the start of measure 2
+    expect(tempos[0].usPerQuarter).toBe(bpmToUs(120));
+    const change = tempos.find((t) => t.usPerQuarter === bpmToUs(60));
+    expect(change).toBeDefined();
+    // divisions defaults to 1, so measure 1's single duration-4 note spans
+    // 4 quarters = 1920 ticks; measure 2 (and its tempo) start there.
+    expect(change!.tick).toBe(1920);
+  });
+});

--- a/tests/playback-sequence.test.ts
+++ b/tests/playback-sequence.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from 'vitest';
+import type { Score, Measure, Barline, DirectionEntry, SoundEntry, NoteEntry } from '../src/types';
+import { generatePlaybackSequence, hasPlaybackControls } from '../src/query/playback-sequence';
+import { exportMidi } from '../src/exporters';
+
+let idCounter = 0;
+const id = () => `id-${idCounter++}`;
+
+function note(octave = 4): NoteEntry {
+  return {
+    _id: id(),
+    type: 'note',
+    pitch: { step: 'C', octave },
+    duration: 4,
+    voice: '1',
+  };
+}
+
+interface MeasureSpec {
+  /** barlines on the measure (repeats, endings) */
+  barlines?: Barline[];
+  /** direction word text, e.g. "D.C. al Fine" */
+  words?: string;
+  /** segno/coda symbol direction-types */
+  symbol?: 'segno' | 'coda';
+  /** standalone <sound> flags */
+  sound?: Partial<Omit<SoundEntry, '_id' | 'type'>>;
+}
+
+function measure(num: number, spec: MeasureSpec = {}): Measure {
+  // Encode the measure number into the pitch (octave) so MIDI note-ons can be
+  // mapped back to their source measure: C(octave=num) -> midi 12*(num+1).
+  const entries: Measure['entries'] = [note(num)];
+
+  if (spec.words) {
+    const dir: DirectionEntry = {
+      _id: id(),
+      type: 'direction',
+      directionTypes: [{ kind: 'words', text: spec.words }],
+    };
+    entries.push(dir);
+  }
+  if (spec.symbol) {
+    const dir: DirectionEntry = {
+      _id: id(),
+      type: 'direction',
+      directionTypes: [{ kind: spec.symbol }],
+    };
+    entries.push(dir);
+  }
+  if (spec.sound) {
+    const s: SoundEntry = { _id: id(), type: 'sound', ...spec.sound };
+    entries.push(s);
+  }
+
+  return {
+    _id: id(),
+    number: String(num),
+    entries,
+    barlines: spec.barlines,
+  };
+}
+
+function forwardRepeat(): Barline {
+  return { _id: id(), location: 'left', repeat: { direction: 'forward' } };
+}
+function backwardRepeat(times = 2): Barline {
+  return { _id: id(), location: 'right', repeat: { direction: 'backward', times } };
+}
+function endingStart(number: string): Barline {
+  return { _id: id(), location: 'left', ending: { number, type: 'start' } };
+}
+function endingStop(number: string): Barline {
+  return { _id: id(), location: 'right', ending: { number, type: 'stop' } };
+}
+
+function scoreOf(measures: Measure[]): Score {
+  return {
+    _id: id(),
+    metadata: {},
+    partList: [{ type: 'score-part', _id: id(), id: 'P1' }],
+    parts: [{ _id: id(), id: 'P1', measures }],
+  } as Score;
+}
+
+/** Convenience: run the sequence and return the played measure numbers (1-based). */
+function play(measures: Measure[]): number[] {
+  const score = scoreOf(measures);
+  return generatePlaybackSequence(score).map((m) => Number(measures[m.measureIndex].number));
+}
+
+describe('generatePlaybackSequence', () => {
+  it('plays straight through when there are no controls', () => {
+    expect(play([measure(1), measure(2), measure(3)])).toEqual([1, 2, 3]);
+  });
+
+  it('hasPlaybackControls reflects presence of structure', () => {
+    expect(hasPlaybackControls(scoreOf([measure(1), measure(2)]))).toBe(false);
+    expect(
+      hasPlaybackControls(scoreOf([measure(1, { barlines: [backwardRepeat()] }), measure(2)]))
+    ).toBe(true);
+  });
+
+  describe('simple repeats', () => {
+    it('repeats a section back to a forward repeat', () => {
+      // |: m1 m2 :| m3
+      const measures = [
+        measure(1, { barlines: [forwardRepeat()] }),
+        measure(2, { barlines: [backwardRepeat()] }),
+        measure(3),
+      ];
+      expect(play(measures)).toEqual([1, 2, 1, 2, 3]);
+    });
+
+    it('repeats from the start of the piece when no forward repeat is marked', () => {
+      // m1 m2 :| m3
+      const measures = [
+        measure(1),
+        measure(2, { barlines: [backwardRepeat()] }),
+        measure(3),
+      ];
+      expect(play(measures)).toEqual([1, 2, 1, 2, 3]);
+    });
+
+    it('honors an explicit repeat count', () => {
+      // |: m1 :|x3
+      const measures = [measure(1, { barlines: [forwardRepeat(), backwardRepeat(3)] })];
+      expect(play(measures)).toEqual([1, 1, 1]);
+    });
+
+    it('handles two sequential (non-nested) repeat sections', () => {
+      // |: m1 :| |: m2 :| m3
+      const measures = [
+        measure(1, { barlines: [forwardRepeat(), backwardRepeat()] }),
+        measure(2, { barlines: [forwardRepeat(), backwardRepeat()] }),
+        measure(3),
+      ];
+      expect(play(measures)).toEqual([1, 1, 2, 2, 3]);
+    });
+  });
+
+  describe('voltas (1st/2nd endings)', () => {
+    it('skips the 1st ending on the repeat pass', () => {
+      // |: m1 [1. m2 :| ] [2. m3 ] m4
+      const measures = [
+        measure(1, { barlines: [forwardRepeat()] }),
+        measure(2, { barlines: [endingStart('1'), backwardRepeat(), endingStop('1')] }),
+        measure(3, { barlines: [endingStart('2'), endingStop('2')] }),
+        measure(4),
+      ];
+      // Pass 1: m1, m2 (ending 1), repeat. Pass 2: m1, skip m2, m3 (ending 2), m4
+      expect(play(measures)).toEqual([1, 2, 1, 3, 4]);
+    });
+  });
+
+  describe('jumps', () => {
+    it('D.C. returns to the beginning once', () => {
+      // m1 m2 m3(D.C.)
+      const measures = [measure(1), measure(2), measure(3, { words: 'D.C.' })];
+      expect(play(measures)).toEqual([1, 2, 3, 1, 2, 3]);
+    });
+
+    it('D.C. al Fine returns to the start and stops at Fine', () => {
+      // m1 m2(Fine) m3 m4(D.C. al Fine)
+      const measures = [
+        measure(1),
+        measure(2, { words: 'Fine' }),
+        measure(3),
+        measure(4, { words: 'D.C. al Fine' }),
+      ];
+      expect(play(measures)).toEqual([1, 2, 3, 4, 1, 2]);
+    });
+
+    it('D.S. al Coda jumps to segno then out to the coda', () => {
+      // m1 m2(Segno) m3(To Coda) m4(D.S. al Coda) m5(Coda)
+      const measures = [
+        measure(1),
+        measure(2, { symbol: 'segno' }),
+        measure(3, { words: 'To Coda' }),
+        measure(4, { words: 'D.S. al Coda' }),
+        measure(5, { symbol: 'coda' }),
+      ];
+      // straight to m4, jump to segno (m2), play m3=To Coda then jump to coda (m5)
+      expect(play(measures)).toEqual([1, 2, 3, 4, 2, 3, 5]);
+    });
+
+    it('detects D.C. from a standalone <sound dacapo>', () => {
+      const measures = [measure(1), measure(2, { sound: { dacapo: true } })];
+      expect(play(measures)).toEqual([1, 2, 1, 2]);
+    });
+  });
+
+  describe('MIDI export integration', () => {
+    // Walk the first part track (track index 1) and return note-on pitches in
+    // time order, then map each pitch back to its source measure number.
+    function playedMeasuresFromMidi(measures: Measure[]): number[] {
+      const data = exportMidi(scoreOf(measures));
+
+      // Skip the 14-byte header, then the conductor track (track 0).
+      let pos = 14;
+      const readChunkLen = (p: number) =>
+        (data[p + 4] << 24) | (data[p + 5] << 16) | (data[p + 6] << 8) | data[p + 7];
+
+      // Track 0 (conductor)
+      const track0Len = readChunkLen(pos);
+      pos += 8 + track0Len;
+
+      // Track 1 (first part)
+      const trackLen = readChunkLen(pos);
+      const bodyStart = pos + 8;
+      const bodyEnd = bodyStart + trackLen;
+
+      const pitches: number[] = [];
+      let i = bodyStart;
+      let runningStatus = 0;
+      const readVarLen = () => {
+        let value = 0;
+        for (;;) {
+          const byte = data[i++];
+          value = (value << 7) | (byte & 0x7f);
+          if (!(byte & 0x80)) break;
+        }
+        return value;
+      };
+
+      while (i < bodyEnd) {
+        readVarLen(); // delta time
+        let status = data[i];
+        if (status & 0x80) {
+          i++;
+          runningStatus = status;
+        } else {
+          status = runningStatus;
+        }
+
+        const hi = status & 0xf0;
+        if (status === 0xff) {
+          i++; // meta type
+          const len = readVarLen();
+          i += len;
+        } else if (hi === 0x90) {
+          const noteNum = data[i++];
+          const vel = data[i++];
+          if (vel > 0) pitches.push(noteNum);
+        } else if (hi === 0x80) {
+          i += 2;
+        } else if (hi === 0xc0 || hi === 0xd0) {
+          i += 1;
+        } else {
+          i += 2;
+        }
+      }
+
+      // midi = 12*(num+1)  ->  num = midi/12 - 1
+      return pitches.map((m) => m / 12 - 1);
+    }
+
+    it('reflects a simple repeat in the rendered note-ons', () => {
+      const measures = [
+        measure(1, { barlines: [forwardRepeat()] }),
+        measure(2, { barlines: [backwardRepeat()] }),
+        measure(3),
+      ];
+      expect(playedMeasuresFromMidi(measures)).toEqual([1, 2, 1, 2, 3]);
+    });
+
+    it('reflects voltas in the rendered note-ons', () => {
+      const measures = [
+        measure(1, { barlines: [forwardRepeat()] }),
+        measure(2, { barlines: [endingStart('1'), backwardRepeat(), endingStop('1')] }),
+        measure(3, { barlines: [endingStart('2'), endingStop('2')] }),
+        measure(4),
+      ];
+      expect(playedMeasuresFromMidi(measures)).toEqual([1, 2, 1, 3, 4]);
+    });
+
+    it('reflects D.C. al Fine in the rendered note-ons', () => {
+      const measures = [
+        measure(1),
+        measure(2, { words: 'Fine' }),
+        measure(3),
+        measure(4, { words: 'D.C. al Fine' }),
+      ];
+      expect(playedMeasuresFromMidi(measures)).toEqual([1, 2, 3, 4, 1, 2]);
+    });
+  });
+});


### PR DESCRIPTION
## 概要
Octava(検証済みプロダクト)の再生ロジックを `musicxml-io` のMIDIエクスポートへ移植し、楽譜が実際に演奏される形をMIDIに反映させます。旧ロジックはフォールバックとして残さず、**単一の経路**に統一しています。

## 変更点

### 1. 構造展開(新規 `src/query/playback-sequence.ts`)
- **繰り返し / 1番・2番括弧(volta) / D.C.・D.S.・Coda・Segno・Fine** のジャンプを1つの状態機械で実際の演奏順へ展開
- 旧 `expandRepeats()`(単純リピートのみ・1番括弧を毎回再生してしまう不具合)を**置き換え**。フォールバックは追加せず一本道に
- `generatePlaybackSequence` / `extractPlaybackControls` / `hasPlaybackControls` を query API として公開

### 2. 表現付きMIDI(`src/exporters/midi.ts`)
- **ベロシティ**: `<dynamics>` 記号(絶対レベル)、sf系の相対アクセント、accent/marcato/tenuto/stress 等のアーティキュレーション倍率
- **装飾音符**: 従来は破棄 → 拍の直前に配置(やや弱め・順に積む・小節跨ぎ対応)
- **テンポ**: metronome に加え `direction` 内 `<sound tempo>` とスタンドアロン `<sound>` も読み、**絶対tick**へ配置(指揮トラックを絶対時間管理に修正)
- `measureEndTick` / `measureMaxPosition` の共通ヘルパ化で小節長計算の重複を解消

## テスト
- 新規23件(playback sequence + MIDIバイト列レベルの velocity/grace/tempo 検証)
- **全950件通過**、typecheck・lint(エラー0)・build OK
- 実フィクスチャ(Saltarello/43e/24a)で end-to-end 動作確認

## スコープ外(follow-up候補)
アーティキュレーションの音長効果(staccato短縮)、ヘアピン velocity 補間、テンポ語(rit./accel.)、装飾/アルペジオ展開、`<sound dynamics>` パーセンテージ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)