### PR TITLE
feat(timeline): フェルマータ・カエスーラ・rit./accel. をテンポで表現（方式A）

### DIFF
--- a/src/exporters/midi.ts
+++ b/src/exporters/midi.ts
@@ -5,13 +5,21 @@ import {
   buildGridTimeline,
   buildTimingSidecar,
   measureEndTick,
+  bpmToUsPerQuarter,
 } from '../query/playback-timeline';
-import type { GridTimeline, TimingSidecar } from '../query/playback-timeline';
+import type {
+  GridTimeline,
+  TimingSidecar,
+  ExpressionOptions,
+} from '../query/playback-timeline';
 
 /**
  * MIDI export options
+ *
+ * Extends {@link ExpressionOptions} so fermata holds and rit./accel. ramps land
+ * in the exported tempo map (and the timing sidecar) identically.
  */
-export interface MidiExportOptions {
+export interface MidiExportOptions extends ExpressionOptions {
   /** Ticks per quarter note (default: 480) */
   ticksPerQuarterNote?: number;
   /** Default tempo in BPM (default: 120) */
@@ -196,8 +204,15 @@ function buildMidiTracks(
   const sequence = generatePlaybackSequence(score);
   const measureOrder = sequence.map((m) => m.measureIndex);
 
-  // Shared time computation: measure spans (ticks) + tempo changes.
-  const grid = buildGridTimeline(score, ticksPerQuarterNote, sequence);
+  // Shared time computation: measure spans (ticks) + tempo changes (including
+  // fermata holds and rit./accel. ramps).
+  const grid = buildGridTimeline(score, ticksPerQuarterNote, sequence, {
+    defaultTempo,
+    fermataHoldMultiplier: options.fermataHoldMultiplier,
+    caesuraSeconds: options.caesuraSeconds,
+    breathSeconds: options.breathSeconds,
+    tempoRampSteps: options.tempoRampSteps,
+  });
 
   // Track 0: Tempo and time signature
   tracks.push(createConductorTrack(score, defaultTempo, grid));
@@ -249,69 +264,77 @@ function pitchToMidiNote(pitch: Pitch, chromaticTranspose: number = 0): number {
 }
 
 /**
- * Create conductor track (initial time signature + all tempo changes).
+ * Create conductor track: all tempo changes and all time-signature changes,
+ * merged in absolute-tick order.
  *
  * Tempo is read from three sources, in document order at each position:
  * metronome direction-types, the <sound tempo> inside a direction, and
- * standalone <sound tempo> entries. Events are placed at absolute ticks so
- * that tempo changes inside repeated sections land correctly.
+ * standalone <sound tempo> entries — plus fermata holds and rit./accel. ramps
+ * folded in by {@link buildGridTimeline}. Time signatures are emitted for every
+ * change across the playback (repeat-expanded) order, not just the first
+ * measure. Events are placed at absolute ticks so changes inside repeated
+ * sections land correctly.
  */
 function createConductorTrack(
   score: Score,
   defaultTempo: number,
   grid: GridTimeline
 ): Uint8Array {
-  const events: number[] = [];
+  // Collect all meta events as (tick, order, bytes); `order` breaks ties so that
+  // at a shared tick the tempo is written before the time signature (matching
+  // the historical tick-0 layout).
+  interface MetaEvent {
+    tick: number;
+    order: number;
+    bytes: number[];
+  }
+  const metaEvents: MetaEvent[] = [];
 
-  // Tempo changes (absolute-tick) come from the shared grid computation.
-  const tempoEvents = [...grid.tempoEvents];
-
-  // Resolve the starting tempo: an explicit tempo at tick 0 wins, else default.
-  tempoEvents.sort((a, b) => a.tick - b.tick);
-  const startBpm = tempoEvents.length > 0 && tempoEvents[0].tick === 0
-    ? tempoEvents[0].bpm
-    : defaultTempo;
-
-  const pushTempo = (deltaTick: number, bpm: number) => {
-    const usPerQuarter = Math.round(60000000 / bpm);
-    events.push(
-      ...writeVariableLength(deltaTick),
-      0xff, 0x51, 0x03,
-      (usPerQuarter >> 16) & 0xff,
-      (usPerQuarter >> 8) & 0xff,
-      usPerQuarter & 0xff
-    );
+  const tempoBytes = (bpm: number): number[] => {
+    const us = bpmToUsPerQuarter(bpm);
+    return [0xff, 0x51, 0x03, (us >> 16) & 0xff, (us >> 8) & 0xff, us & 0xff];
   };
 
-  // Initial tempo at tick 0.
-  pushTempo(0, startBpm);
-
-  // Initial time signature from the first measure.
-  if (score.parts.length > 0 && score.parts[0].measures.length > 0) {
-    const time = score.parts[0].measures[0].attributes?.time;
-    if (time) {
-      const numerator = parseInt(time.beats, 10) || 4;
-      const denominator = Math.log2(time.beatType);
-      events.push(
-        ...writeVariableLength(0),
-        0xff, 0x58, 0x04,
-        numerator,
-        denominator,
-        24,
-        8
-      );
-    }
-  }
-
-  // Remaining tempo changes, as deltas from the previous event.
-  let lastTick = 0;
+  // --- Tempo changes (deduped, mirroring makeTickToSec). ---
+  const tempoEvents = [...grid.tempoEvents].sort((a, b) => a.tick - b.tick);
+  const startBpm =
+    tempoEvents.length > 0 && tempoEvents[0].tick === 0 ? tempoEvents[0].bpm : defaultTempo;
+  metaEvents.push({ tick: 0, order: 0, bytes: tempoBytes(startBpm) });
   let lastBpm = startBpm;
   for (const ev of tempoEvents) {
     if (ev.tick === 0) continue; // already emitted as the initial tempo
     if (ev.bpm === lastBpm) continue; // no audible change
-    pushTempo(ev.tick - lastTick, ev.bpm);
-    lastTick = ev.tick;
+    metaEvents.push({ tick: ev.tick, order: 0, bytes: tempoBytes(ev.bpm) });
     lastBpm = ev.bpm;
+  }
+
+  // --- Time-signature changes across the played measures. ---
+  const part = score.parts.length > 0 ? score.parts[0] : undefined;
+  if (part) {
+    let lastSig: string | null = null;
+    for (const m of grid.measures) {
+      const time = part.measures[m.measureIndex]?.attributes?.time;
+      if (!time) continue; // unchanged from the prevailing signature
+      const numerator = parseInt(time.beats, 10) || 4;
+      const denominator = Math.log2(time.beatType);
+      const sig = `${numerator}/${denominator}`;
+      if (sig === lastSig) continue;
+      lastSig = sig;
+      metaEvents.push({
+        tick: m.startTick,
+        order: 1,
+        bytes: [0xff, 0x58, 0x04, numerator, denominator, 24, 8],
+      });
+    }
+  }
+
+  // --- Emit as delta-timed meta events. ---
+  metaEvents.sort((a, b) => a.tick - b.tick || a.order - b.order);
+  const events: number[] = [];
+  let lastTick = 0;
+  for (const ev of metaEvents) {
+    events.push(...writeVariableLength(ev.tick - lastTick), ...ev.bytes);
+    lastTick = ev.tick;
   }
 
   // End of track

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,7 +179,7 @@ export {
   countNotes,
   scoresEqual,
 } from './query';
-export type { VoiceFilter, NormalizedPositionOptions, PitchRange, FindNotesFilter, RoundtripMetrics, PlaybackMeasure, PlaybackControls, TimingMapOptions, TimingSidecar, TimingBreakpoint } from './query';
+export type { VoiceFilter, NormalizedPositionOptions, PitchRange, FindNotesFilter, RoundtripMetrics, PlaybackMeasure, PlaybackControls, TimingMapOptions, TimingSidecar, TimingBreakpoint, ExpressionOptions, ExpressionHint, ExpressionKind } from './query';
 
 // Operations (re-export for convenience)
 export {

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -62,7 +62,14 @@ export type { PlaybackMeasure, PlaybackControls } from './playback-sequence';
 
 // Playback timeline (seconds ↔ musical position, repeat-expanded)
 export { generatePlaybackTimeline } from './playback-timeline';
-export type { TimingMapOptions, TimingSidecar, TimingBreakpoint } from './playback-timeline';
+export type {
+  TimingMapOptions,
+  TimingSidecar,
+  TimingBreakpoint,
+  ExpressionOptions,
+  ExpressionHint,
+  ExpressionKind,
+} from './playback-timeline';
 
 export interface VoiceFilter {
   voice?: string;

--- a/src/query/playback-timeline.ts
+++ b/src/query/playback-timeline.ts
@@ -14,11 +14,46 @@
  * therefore equal to the playback time of the MIDI produced by `exportMidi`,
  * which shares this exact timeline computation.
  */
-import type { Score, Part, Measure } from '../types';
+import type { Score, Part, Measure, NoteEntry } from '../types';
 import { generatePlaybackSequence } from './playback-sequence';
 
+/**
+ * Expressive-timing options shared by the MIDI exporter and the timeline query.
+ *
+ * These shape the TEMPO map only — never note durations. The whole module
+ * follows "method A": notated tick lengths (and therefore `quarterPos`) are the
+ * score's, and every expressive change in elapsed time is carried by tempo
+ * (`set_tempo`). This keeps `tick ÷ tpqn` exactly equal to the musical quarter
+ * position so the sidecar maps with zero drift.
+ */
+export interface ExpressionOptions {
+  /**
+   * Fermata hold factor: a fermata note/rest's tick span is stretched in
+   * elapsed time by this factor by dividing the prevailing BPM over the span
+   * (e.g. 2 → the span plays at half BPM, lasting twice as long). The note's
+   * tick length and `quarterPos` are unchanged. `1` disables. Default `1.75`.
+   */
+  fermataHoldMultiplier?: number;
+  /**
+   * Seconds of extra time a caesura ("railroad tracks") inserts, modelled as a
+   * tempo dip over the tail of the note carrying it (no tick is added).
+   * Default `0.4`. `0` disables.
+   */
+  caesuraSeconds?: number;
+  /**
+   * Seconds of extra time a breath mark inserts, modelled like a caesura but
+   * shorter. Default `0.25`. `0` disables.
+   */
+  breathSeconds?: number;
+  /**
+   * Number of discrete `set_tempo` steps used to approximate a rit./accel.
+   * tempo ramp between two tempo anchors. Higher = smoother. Default `12`.
+   */
+  tempoRampSteps?: number;
+}
+
 /** Options controlling the rendered timeline. */
-export interface TimingMapOptions {
+export interface TimingMapOptions extends ExpressionOptions {
   /**
    * Ticks per quarter note (default: 480). Only affects internal tick rounding;
    * `midiSec`/`quarterPos` are otherwise independent of it.
@@ -27,6 +62,12 @@ export interface TimingMapOptions {
   /** Default tempo in BPM when the score carries no tempo marking (default: 120). */
   defaultTempo?: number;
 }
+
+/** Resolved expressive-timing defaults. */
+const DEFAULT_FERMATA_HOLD = 1.75;
+const DEFAULT_CAESURA_SECONDS = 0.4;
+const DEFAULT_BREATH_SECONDS = 0.25;
+const DEFAULT_RAMP_STEPS = 12;
 
 /** A single point on the timeline: a time ↔ musical-position correspondence. */
 export interface TimingBreakpoint {
@@ -65,6 +106,32 @@ export interface TimingSidecar {
   ticksPerQuarterNote: number;
   /** Breakpoints, sorted ascending and monotone by `midiSec`. */
   breakpoints: TimingBreakpoint[];
+  /**
+   * Expressive-timing regions (fermatas, caesuras, breaths, rit./accel.). An
+   * aligner can relax its time constraints inside these spans, since the human
+   * performance is free to depart most from the grid there. Sorted by
+   * `fromMidiSec`. Omitted entirely when there are none.
+   */
+  expressions?: ExpressionHint[];
+}
+
+/** The kind of expressive timing a span represents. */
+export type ExpressionKind = 'fermata' | 'caesura' | 'breath' | 'rit' | 'accel';
+
+/** A time region (in MIDI seconds) carrying expressive tempo change. */
+export interface ExpressionHint {
+  type: ExpressionKind;
+  /** Start of the region in MIDI seconds. */
+  fromMidiSec: number;
+  /** End of the region in MIDI seconds. */
+  toMidiSec: number;
+}
+
+/** A time region in absolute ticks, before conversion to seconds. */
+export interface ExpressionSpan {
+  type: ExpressionKind;
+  startTick: number;
+  endTick: number;
 }
 
 /** A tempo change at an absolute tick. */
@@ -88,12 +155,18 @@ export interface GridMeasure {
  * the tempo changes. Computed once so the two outputs can never drift.
  */
 export interface GridTimeline {
-  /** Tempo changes in document order (unsorted). */
+  /**
+   * Tempo changes (absolute tick), already expanded to include fermata dips and
+   * rit./accel. ramp steps. Treated as piecewise-constant by both the MIDI
+   * conductor track and the sidecar, so the two never drift.
+   */
   tempoEvents: TempoChange[];
   /** Played measures in playback (repeat-expanded) order. */
   measures: GridMeasure[];
   /** Absolute tick at the end of the last measure. */
   totalTicks: number;
+  /** Expressive-timing regions (fermata/caesura/breath/rit./accel.), in ticks. */
+  expressions: ExpressionSpan[];
 }
 
 /** Parse a metronome per-minute value to a numeric BPM, or null. */
@@ -185,27 +258,102 @@ export function measureEndTick(
   return measureStartTick + actualTicks;
 }
 
+/** Does this note/rest carry a fermata notation? */
+function hasFermata(note: NoteEntry): boolean {
+  return note.notations?.some((n) => n.type === 'fermata') ?? false;
+}
+
+/**
+ * If a note carries a caesura or breath-mark articulation, return which one.
+ * (Both are modelled as a short held pause after the note.)
+ */
+function pauseArticulation(note: NoteEntry): 'caesura' | 'breath' | null {
+  if (!note.notations) return null;
+  for (const n of note.notations) {
+    if (n.type === 'articulation') {
+      if (n.articulation === 'caesura') return 'caesura';
+      if (n.articulation === 'breath-mark') return 'breath';
+    }
+  }
+  return null;
+}
+
+/**
+ * Recognise a rit./accel.-family tempo word (the printed text of a `words`
+ * direction). These trigger a continuous tempo ramp toward the next anchor;
+ * the returned kind only labels the span (the actual direction follows the
+ * anchors).
+ */
+function tempoRampWord(text: string): 'rit' | 'accel' | null {
+  const t = text.trim().toLowerCase().replace(/[.\s]+$/, '');
+  if (!t) return null;
+  // Slowing: ritardando, ritenuto, rallentando, allargando, slargando, calando, smorzando.
+  if (/^(rit|riten|rall|allarg|slarg|cala|smorz|morend)/.test(t)) return 'rit';
+  // Speeding: accelerando, stringendo, affrettando, incalzando.
+  if (/^(accel|string|affret|incalz|pi[uù]\s*mosso)/.test(t)) return 'accel';
+  return null;
+}
+
+/** A pending rit./accel. marker discovered while walking the grid. */
+interface RampMarker {
+  tick: number;
+  kind: 'rit' | 'accel';
+}
+
+/** A region whose elapsed time is stretched by dividing the BPM by `factor`. */
+interface StretchInterval {
+  startTick: number;
+  endTick: number;
+  factor: number;
+  /** Label for the sidecar expression hint. */
+  type: ExpressionKind;
+}
+
 /**
  * Walk the first part in playback (repeat-expanded) order and record, for each
  * played measure, the absolute tick span it occupies, plus every tempo change
  * as an absolute-tick event. This is the single source of truth both the MIDI
  * tempo map and the timing sidecar are built from, so they always agree.
+ *
+ * Expressive timing (fermata, caesura/breath, rit./accel.) is folded into the
+ * returned `tempoEvents` as ordinary tempo changes — never into note durations.
+ * Notated tick spans (and hence `quarterPos`) are untouched.
  */
 export function buildGridTimeline(
   score: Score,
   ticksPerQuarterNote: number,
-  sequence: { measureIndex: number; repeatIteration: number }[]
+  sequence: { measureIndex: number; repeatIteration: number }[],
+  options: ExpressionOptions & { defaultTempo?: number } = {}
 ): GridTimeline {
-  const tempoEvents: TempoChange[] = [];
+  const rawTempo: TempoChange[] = [];
   const measures: GridMeasure[] = [];
+  const rampMarkers: RampMarker[] = [];
+  const stretches: StretchInterval[] = [];
 
   if (score.parts.length === 0) {
-    return { tempoEvents, measures, totalTicks: 0 };
+    return { tempoEvents: [], measures, totalTicks: 0, expressions: [] };
   }
+
+  const fermataHold = options.fermataHoldMultiplier ?? DEFAULT_FERMATA_HOLD;
+  const caesuraSeconds = options.caesuraSeconds ?? DEFAULT_CAESURA_SECONDS;
+  const breathSeconds = options.breathSeconds ?? DEFAULT_BREATH_SECONDS;
+  const rampSteps = Math.max(1, Math.round(options.tempoRampSteps ?? DEFAULT_RAMP_STEPS));
+  const defaultTempo = options.defaultTempo ?? 120;
 
   const part = score.parts[0];
   let divisions = 1;
   let currentTick = 0;
+  // Prevailing BPM from explicit anchors, used to size a caesura/breath dip.
+  let prevailingBpm = defaultTempo;
+
+  // Convert a pause in seconds to a stretch factor over a tick window: the
+  // window's notated time is `windowTicks/tpqn * 60/bpm`, and we want to add
+  // `pauseSeconds` to it.
+  const pauseFactor = (windowTicks: number, bpm: number, pauseSeconds: number): number => {
+    const baseSeconds = (windowTicks / ticksPerQuarterNote) * (60 / bpm);
+    if (baseSeconds <= 0) return 1;
+    return (baseSeconds + pauseSeconds) / baseSeconds;
+  };
 
   for (const { measureIndex, repeatIteration } of sequence) {
     const measure = part.measures[measureIndex];
@@ -216,6 +364,7 @@ export function buildGridTimeline(
 
     const measureStartTick = currentTick;
     let position = 0;
+    let chordBasePosition = 0;
     const tickAt = (pos: number) =>
       measureStartTick + Math.round((pos * ticksPerQuarterNote) / divisions);
 
@@ -224,16 +373,60 @@ export function buildGridTimeline(
         for (const dirType of entry.directionTypes) {
           if (dirType.kind === 'metronome') {
             const bpm = metronomeBpm(dirType.perMinute);
-            if (bpm !== null) tempoEvents.push({ tick: tickAt(position), bpm });
+            if (bpm !== null) {
+              rawTempo.push({ tick: tickAt(position), bpm });
+              prevailingBpm = bpm;
+            }
+          } else if (dirType.kind === 'words') {
+            const kind = tempoRampWord(dirType.text);
+            if (kind) rampMarkers.push({ tick: tickAt(position), kind });
           }
         }
         if (entry.sound?.tempo) {
-          tempoEvents.push({ tick: tickAt(position), bpm: entry.sound.tempo });
+          rawTempo.push({ tick: tickAt(position), bpm: entry.sound.tempo });
+          prevailingBpm = entry.sound.tempo;
         }
       } else if (entry.type === 'sound') {
-        if (entry.tempo) tempoEvents.push({ tick: tickAt(position), bpm: entry.tempo });
-      } else if (entry.type === 'note' && !entry.chord) {
-        position += entry.duration;
+        if (entry.tempo) {
+          rawTempo.push({ tick: tickAt(position), bpm: entry.tempo });
+          prevailingBpm = entry.tempo;
+        }
+      } else if (entry.type === 'note') {
+        const notePos = entry.chord ? chordBasePosition : position;
+        const noteStartTick = tickAt(notePos);
+        const noteEndTick = tickAt(notePos + entry.duration);
+
+        if (noteEndTick > noteStartTick) {
+          if (fermataHold !== 1 && hasFermata(entry)) {
+            // Hold the whole note span at a fraction of the prevailing tempo.
+            stretches.push({
+              startTick: noteStartTick,
+              endTick: noteEndTick,
+              factor: fermataHold,
+              type: 'fermata',
+            });
+          }
+          const pause = pauseArticulation(entry);
+          if (pause) {
+            const seconds = pause === 'caesura' ? caesuraSeconds : breathSeconds;
+            if (seconds > 0) {
+              // Dip the tail of the note (capped at a quarter note) so the break
+              // happens after the note sounds, without moving any onset.
+              const window = Math.min(noteEndTick - noteStartTick, ticksPerQuarterNote);
+              stretches.push({
+                startTick: noteEndTick - window,
+                endTick: noteEndTick,
+                factor: pauseFactor(window, prevailingBpm, seconds),
+                type: pause,
+              });
+            }
+          }
+        }
+
+        if (!entry.chord) {
+          chordBasePosition = position;
+          position += entry.duration;
+        }
       } else if (entry.type === 'backup') {
         position -= entry.duration;
       } else if (entry.type === 'forward') {
@@ -261,14 +454,133 @@ export function buildGridTimeline(
     currentTick = endTick;
   }
 
-  return { tempoEvents, measures, totalTicks: currentTick };
+  const { tempoEvents, expressions } = bakeTempoMap(
+    rawTempo,
+    rampMarkers,
+    stretches,
+    defaultTempo,
+    rampSteps
+  );
+
+  return { tempoEvents, measures, totalTicks: currentTick, expressions };
+}
+
+/**
+ * Combine explicit tempo anchors, rit./accel. ramp markers, and time-stretch
+ * intervals (fermata/caesura/breath) into a single piecewise-constant tempo
+ * map. Ramps become a staircase of small steps; stretches divide the prevailing
+ * BPM over their span. The result is consumed identically by the MIDI conductor
+ * track and the sidecar, so elapsed seconds can never diverge between them.
+ */
+function bakeTempoMap(
+  rawTempo: TempoChange[],
+  rampMarkers: RampMarker[],
+  stretches: StretchInterval[],
+  defaultTempo: number,
+  rampSteps: number
+): { tempoEvents: TempoChange[]; expressions: ExpressionSpan[] } {
+  // --- Base tempo as change points (mirrors the conductor track's dedup). ---
+  const sortedRaw = [...rawTempo].sort((a, b) => a.tick - b.tick);
+  const startBpm =
+    sortedRaw.length > 0 && sortedRaw[0].tick === 0 ? sortedRaw[0].bpm : defaultTempo;
+  const baseChanges: TempoChange[] = [{ tick: 0, bpm: startBpm }];
+  let lastBpm = startBpm;
+  for (const ev of sortedRaw) {
+    if (ev.tick === 0) continue;
+    if (ev.bpm === lastBpm) continue;
+    // Collapse same-tick anchors: the last one at a tick wins.
+    if (baseChanges[baseChanges.length - 1].tick === ev.tick) {
+      baseChanges[baseChanges.length - 1].bpm = ev.bpm;
+    } else {
+      baseChanges.push({ tick: ev.tick, bpm: ev.bpm });
+    }
+    lastBpm = ev.bpm;
+  }
+
+  const baseBpmAt = (tick: number): number => {
+    let i = baseChanges.length - 1;
+    while (i > 0 && baseChanges[i].tick > tick) i--;
+    return baseChanges[i].bpm;
+  };
+
+  // --- Expand rit./accel. markers into staircase ramp points. ---
+  const rampExpressions: ExpressionSpan[] = [];
+  const rampPoints: TempoChange[] = [];
+  for (const marker of rampMarkers) {
+    // Target = first base change strictly after the marker with a different BPM.
+    const from = baseBpmAt(marker.tick);
+    const next = baseChanges.find((c) => c.tick > marker.tick && c.bpm !== from);
+    if (!next) continue; // No anchor to ramp toward; leave tempo as-is.
+    const span = next.tick - marker.tick;
+    if (span <= 0) continue;
+    for (let k = 1; k < rampSteps; k++) {
+      const tick = Math.round(marker.tick + (span * k) / rampSteps);
+      if (tick <= marker.tick || tick >= next.tick) continue;
+      const bpm = from + ((next.bpm - from) * k) / rampSteps;
+      rampPoints.push({ tick, bpm });
+    }
+    rampExpressions.push({ type: marker.kind, startTick: marker.tick, endTick: next.tick });
+  }
+
+  // Merge base changes and ramp points into a single sorted step list. Where a
+  // ramp point shares a tick with a base change, the base change wins.
+  const baseTicks = new Set(baseChanges.map((c) => c.tick));
+  const stepList: TempoChange[] = [...baseChanges];
+  for (const p of rampPoints) {
+    if (!baseTicks.has(p.tick)) stepList.push(p);
+  }
+  stepList.sort((a, b) => a.tick - b.tick);
+  const stepBpmAt = (tick: number): number => {
+    let i = stepList.length - 1;
+    while (i > 0 && stepList[i].tick > tick) i--;
+    return stepList[i].bpm;
+  };
+
+  // --- Apply stretch intervals over the stepped base. ---
+  const boundaries = new Set<number>(stepList.map((s) => s.tick));
+  for (const s of stretches) {
+    boundaries.add(s.startTick);
+    boundaries.add(s.endTick);
+  }
+  const sortedBoundaries = [...boundaries].sort((a, b) => a - b);
+
+  const tempoEvents: TempoChange[] = [];
+  let emittedBpm: number | null = null;
+  for (const tick of sortedBoundaries) {
+    let bpm = stepBpmAt(tick);
+    for (const s of stretches) {
+      if (tick >= s.startTick && tick < s.endTick) bpm /= s.factor;
+    }
+    if (emittedBpm === null || bpm !== emittedBpm) {
+      tempoEvents.push({ tick, bpm });
+      emittedBpm = bpm;
+    }
+  }
+
+  const expressions: ExpressionSpan[] = [
+    ...stretches.map((s) => ({ type: s.type, startTick: s.startTick, endTick: s.endTick })),
+    ...rampExpressions,
+  ].sort((a, b) => a.startTick - b.startTick || a.endTick - b.endTick);
+
+  return { tempoEvents, expressions };
+}
+
+/**
+ * Microseconds per quarter note for a BPM, exactly as the MIDI `set_tempo`
+ * meta-event stores it. Both the conductor track and {@link makeTickToSec} go
+ * through this, so the sidecar's seconds match real MIDI playback to the
+ * microsecond (with no per-step rounding drift, which matters once rit./accel.
+ * ramps introduce many fractional BPM steps).
+ */
+export function bpmToUsPerQuarter(bpm: number): number {
+  return Math.round(60000000 / bpm);
 }
 
 /**
  * Build a tick→seconds converter from a tempo map, using the SAME tempo-change
  * points the conductor track emits (initial tempo at tick 0, then changes where
- * the BPM actually differs). This guarantees `midiSec` matches the playback time
- * of the generated MIDI.
+ * the BPM actually differs) and the SAME rounded microseconds-per-quarter. This
+ * guarantees `midiSec` matches the playback time of the generated MIDI.
  */
 function makeTickToSec(
   tempoEvents: TempoChange[],
@@ -278,27 +590,32 @@ function makeTickToSec(
   const sorted = [...tempoEvents].sort((a, b) => a.tick - b.tick);
   const startBpm = sorted.length > 0 && sorted[0].tick === 0 ? sorted[0].bpm : defaultTempo;
 
-  // Effective change points (mirrors the conductor track's emission).
-  const changes: TempoChange[] = [{ tick: 0, bpm: startBpm }];
+  // Effective change points (mirrors the conductor track's emission), carrying
+  // the rounded microseconds-per-quarter the MIDI actually stores.
+  const changes: { tick: number; usPerQuarter: number }[] = [
+    { tick: 0, usPerQuarter: bpmToUsPerQuarter(startBpm) },
+  ];
   let lastBpm = startBpm;
   for (const ev of sorted) {
     if (ev.tick === 0) continue;
     if (ev.bpm === lastBpm) continue;
-    changes.push({ tick: ev.tick, bpm: ev.bpm });
+    changes.push({ tick: ev.tick, usPerQuarter: bpmToUsPerQuarter(ev.bpm) });
     lastBpm = ev.bpm;
   }
+
+  const secPerTick = (usPerQuarter: number) => usPerQuarter / 1_000_000 / ticksPerQuarterNote;
 
   // Cumulative seconds at the start of each segment.
   const cumSec: number[] = [0];
   for (let i = 1; i < changes.length; i++) {
     const dTick = changes[i].tick - changes[i - 1].tick;
-    cumSec[i] = cumSec[i - 1] + (dTick / ticksPerQuarterNote) * (60 / changes[i - 1].bpm);
+    cumSec[i] = cumSec[i - 1] + dTick * secPerTick(changes[i - 1].usPerQuarter);
   }
 
   return (tick: number) => {
     let i = changes.length - 1;
     while (i > 0 && changes[i].tick > tick) i--;
-    return cumSec[i] + ((tick - changes[i].tick) / ticksPerQuarterNote) * (60 / changes[i].bpm);
+    return cumSec[i] + (tick - changes[i].tick) * secPerTick(changes[i].usPerQuarter);
   };
 }
 
@@ -354,12 +671,24 @@ export function buildTimingSidecar(
 
   breakpoints.sort((a, b) => a.midiSec - b.midiSec || a.quarterPos - b.quarterPos);
 
-  return {
+  const sidecar: TimingSidecar = {
     version: '1',
     durationSec: tickToSec(grid.totalTicks),
     ticksPerQuarterNote,
     breakpoints,
   };
+
+  if (grid.expressions.length > 0) {
+    sidecar.expressions = grid.expressions
+      .map((e) => ({
+        type: e.type,
+        fromMidiSec: tickToSec(e.startTick),
+        toMidiSec: tickToSec(e.endTick),
+      }))
+      .sort((a, b) => a.fromMidiSec - b.fromMidiSec || a.toMidiSec - b.toMidiSec);
+  }
+
+  return sidecar;
 }
 
 /**
@@ -378,6 +707,12 @@ export function generatePlaybackTimeline(
   const ticksPerQuarterNote = options.ticksPerQuarterNote ?? 480;
   const defaultTempo = options.defaultTempo ?? 120;
   const sequence = generatePlaybackSequence(score);
-  const grid = buildGridTimeline(score, ticksPerQuarterNote, sequence);
+  const grid = buildGridTimeline(score, ticksPerQuarterNote, sequence, {
+    defaultTempo,
+    fermataHoldMultiplier: options.fermataHoldMultiplier,
+    caesuraSeconds: options.caesuraSeconds,
+    breathSeconds: options.breathSeconds,
+    tempoRampSteps: options.tempoRampSteps,
+  });
   return buildTimingSidecar(grid, defaultTempo, ticksPerQuarterNote);
 }

--- a/tests/midi-expressive-timing.test.ts
+++ b/tests/midi-expressive-timing.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  Score,
+  Measure,
+  NoteEntry,
+  DirectionEntry,
+  SoundEntry,
+  TimeSignature,
+} from '../src/types';
+import { exportMidi, exportMidiWithTimingMap } from '../src/exporters';
+import { generatePlaybackTimeline } from '../src/query';
+
+let idCounter = 0;
+const id = () => `ex-${idCounter++}`;
+
+const TPQN = 480;
+
+// ---- Score builders -------------------------------------------------------
+
+/** A note; `duration` is in divisions (scores below use divisions=1 → quarters). */
+function note(opts: { step?: string; octave?: number; duration?: number; fermata?: boolean } = {}): NoteEntry {
+  const n: NoteEntry = {
+    _id: id(),
+    type: 'note',
+    pitch: { step: (opts.step ?? 'C') as any, octave: opts.octave ?? 4 },
+    duration: opts.duration ?? 4,
+    voice: '1',
+  };
+  if (opts.fermata) n.notations = [{ type: 'fermata' }];
+  return n;
+}
+
+function caesuraNote(): NoteEntry {
+  return {
+    _id: id(),
+    type: 'note',
+    pitch: { step: 'C', octave: 4 },
+    duration: 4,
+    voice: '1',
+    notations: [{ type: 'articulation', articulation: 'caesura' }],
+  };
+}
+
+function metronomeDir(perMinute: number): DirectionEntry {
+  return {
+    _id: id(),
+    type: 'direction',
+    directionTypes: [{ kind: 'metronome', beatUnit: 'quarter', perMinute }],
+  };
+}
+
+function soundTempoDir(tempo: number): DirectionEntry {
+  return { _id: id(), type: 'direction', directionTypes: [], sound: { tempo } };
+}
+
+function standaloneSoundTempo(tempo: number): SoundEntry {
+  return { _id: id(), type: 'sound', tempo };
+}
+
+function wordsDir(text: string): DirectionEntry {
+  return { _id: id(), type: 'direction', directionTypes: [{ kind: 'words', text }] };
+}
+
+function measure(num: number, entries: Measure['entries'], time?: TimeSignature): Measure {
+  const m: Measure = { _id: id(), number: String(num), entries };
+  if (time) m.attributes = { time };
+  return m;
+}
+
+function ts(beats: number, beatType: number): TimeSignature {
+  return { beats: String(beats), beatType };
+}
+
+function scoreOf(measures: Measure[]): Score {
+  return {
+    _id: id(),
+    metadata: {},
+    partList: [{ type: 'score-part', _id: id(), id: 'P1' }],
+    parts: [{ _id: id(), id: 'P1', measures }],
+  } as Score;
+}
+
+// ---- MIDI parser (tempos + time signatures) -------------------------------
+
+interface ConductorEvents {
+  tempos: { tick: number; usPerQuarter: number }[];
+  timeSigs: { tick: number; numerator: number; denominator: number }[];
+}
+
+function parseConductor(data: Uint8Array): ConductorEvents {
+  let pos = 14; // skip 14-byte MThd
+  const u32 = (p: number) =>
+    (data[p] << 24) | (data[p + 1] << 16) | (data[p + 2] << 8) | data[p + 3];
+
+  // Conductor track is track 0.
+  const len = u32(pos + 4);
+  const bodyStart = pos + 8;
+  const bodyEnd = bodyStart + len;
+
+  const ev: ConductorEvents = { tempos: [], timeSigs: [] };
+  let i = bodyStart;
+  let tick = 0;
+  const readVarLen = () => {
+    let value = 0;
+    for (;;) {
+      const byte = data[i++];
+      value = (value << 7) | (byte & 0x7f);
+      if (!(byte & 0x80)) break;
+    }
+    return value;
+  };
+
+  while (i < bodyEnd) {
+    tick += readVarLen();
+    const status = data[i++];
+    if (status === 0xff) {
+      const metaType = data[i++];
+      const metaLen = readVarLen();
+      if (metaType === 0x51 && metaLen === 3) {
+        ev.tempos.push({
+          tick,
+          usPerQuarter: (data[i] << 16) | (data[i + 1] << 8) | data[i + 2],
+        });
+      } else if (metaType === 0x58 && metaLen === 4) {
+        ev.timeSigs.push({ tick, numerator: data[i], denominator: data[i + 1] });
+      }
+      i += metaLen;
+    } else {
+      // No channel events are expected on the conductor track.
+      break;
+    }
+  }
+  return ev;
+}
+
+/** Tick → seconds using the parsed (piecewise-constant) MIDI tempo map. */
+function midiTickToSec(tempos: { tick: number; usPerQuarter: number }[], tick: number): number {
+  const sorted = [...tempos].sort((a, b) => a.tick - b.tick);
+  const cum: number[] = [0];
+  for (let i = 1; i < sorted.length; i++) {
+    const dTick = sorted[i].tick - sorted[i - 1].tick;
+    cum[i] = cum[i - 1] + (dTick * sorted[i - 1].usPerQuarter) / 1_000_000 / TPQN;
+  }
+  let i = sorted.length - 1;
+  while (i > 0 && sorted[i].tick > tick) i--;
+  return cum[i] + ((tick - sorted[i].tick) * sorted[i].usPerQuarter) / 1_000_000 / TPQN;
+}
+
+// ---- Tests ----------------------------------------------------------------
+
+describe('fermata as a local tempo dip', () => {
+  // m1 note, m2 fermata note, m3 note — all single whole-measure notes at 120 BPM
+  // (divisions=1 → 4 quarters = 1920 ticks = 2 s/measure).
+  const score = scoreOf([
+    measure(1, [note()]),
+    measure(2, [note({ fermata: true })]),
+    measure(3, [note()]),
+  ]);
+
+  it('stretches the fermata note in time by the hold multiplier, leaving quarterPos untouched', () => {
+    const sidecar = generatePlaybackTimeline(score, { fermataHoldMultiplier: 2 });
+    const byMeasure = (n: string) =>
+      sidecar.breakpoints.find((b) => b.measureNumber === n && b.beatInMeasure === 0)!;
+
+    // m2's note holds at half tempo, so it lasts 4 s instead of 2 s.
+    expect(byMeasure('2').midiSec).toBeCloseTo(2, 9); // m1 at 120 BPM
+    expect(byMeasure('3').midiSec).toBeCloseTo(6, 9); // 2 + 4 (stretched), not 4
+    expect(sidecar.durationSec).toBeCloseTo(8, 9); // m3 plays at 120 again
+
+    // quarterPos is purely notated and must not move (method A, not B).
+    expect(byMeasure('2').quarterPos).toBe(4);
+    expect(byMeasure('3').quarterPos).toBe(8);
+  });
+
+  it('keeps quarterPos identical with and without the hold (B-method guard)', () => {
+    const held = generatePlaybackTimeline(score, { fermataHoldMultiplier: 2 });
+    const plain = generatePlaybackTimeline(score, { fermataHoldMultiplier: 1 });
+    expect(held.breakpoints.map((b) => b.quarterPos)).toEqual(
+      plain.breakpoints.map((b) => b.quarterPos)
+    );
+    // ...but the elapsed seconds differ (time came from tempo, not from ticks).
+    expect(held.durationSec).toBeGreaterThan(plain.durationSec);
+  });
+
+  it('emits a fermata expression hint over the stretched seconds', () => {
+    const sidecar = generatePlaybackTimeline(score, { fermataHoldMultiplier: 2 });
+    expect(sidecar.expressions).toBeDefined();
+    const fermata = sidecar.expressions!.find((e) => e.type === 'fermata')!;
+    expect(fermata.fromMidiSec).toBeCloseTo(2, 9);
+    expect(fermata.toMidiSec).toBeCloseTo(6, 9);
+  });
+
+  it('disabling the hold (multiplier 1) leaves the tempo flat', () => {
+    const sidecar = generatePlaybackTimeline(score, { fermataHoldMultiplier: 1 });
+    expect(sidecar.durationSec).toBeCloseTo(6, 9);
+    expect(sidecar.expressions).toBeUndefined();
+  });
+
+  it('reflects the fermata hold in the MIDI tempo map too', () => {
+    const { midi } = exportMidiWithTimingMap(score, { fermataHoldMultiplier: 2 });
+    const { tempos } = parseConductor(midi);
+    // 120 BPM (initial), 60 BPM over the fermata span, back to 120 after it.
+    expect(tempos.map((t) => t.usPerQuarter)).toEqual([
+      Math.round(60000000 / 120),
+      Math.round(60000000 / 60),
+      Math.round(60000000 / 120),
+    ]);
+    expect(tempos[1].tick).toBe(1920); // m2 start
+    expect(tempos[2].tick).toBe(3840); // m3 start
+  });
+});
+
+describe('caesura inserts held time without moving onsets', () => {
+  const score = scoreOf([measure(1, [caesuraNote()]), measure(2, [note()])]);
+
+  it('adds the configured pause seconds and keeps quarterPos', () => {
+    const withPause = generatePlaybackTimeline(score, { caesuraSeconds: 1 });
+    const noPause = generatePlaybackTimeline(score, { caesuraSeconds: 0 });
+
+    const m2With = withPause.breakpoints.find((b) => b.measureNumber === '2')!;
+    const m2No = noPause.breakpoints.find((b) => b.measureNumber === '2')!;
+
+    expect(m2With.quarterPos).toBe(m2No.quarterPos); // onset grid unchanged
+    expect(m2With.midiSec).toBeCloseTo(m2No.midiSec + 1, 6); // ~1 s inserted
+    expect(withPause.expressions!.some((e) => e.type === 'caesura')).toBe(true);
+  });
+});
+
+describe('rit./accel. continuous tempo interpolation', () => {
+  // m1 @120, m2 has "rit." and ramps toward m3's @60.
+  const score = scoreOf([
+    measure(1, [metronomeDir(120), note()]),
+    measure(2, [wordsDir('rit.'), note()]),
+    measure(3, [metronomeDir(60), note()]),
+  ]);
+
+  it('bakes a staircase of distinct tempo steps between the two anchors', () => {
+    const { midi } = exportMidiWithTimingMap(score, { tempoRampSteps: 8 });
+    const { tempos } = parseConductor(midi);
+
+    // Steps that live strictly inside the ramp span (1920 < tick < 3840).
+    const rampTicks = tempos.filter((t) => t.tick > 1920 && t.tick < 3840);
+    expect(rampTicks.length).toBeGreaterThan(1); // not a single step
+
+    // Tempo decreases monotonically across the ramp (BPM down → us/quarter up).
+    for (let i = 1; i < tempos.length; i++) {
+      if (tempos[i].tick <= 1920) continue;
+      if (tempos[i].tick > 3840) continue;
+      expect(tempos[i].usPerQuarter).toBeGreaterThan(tempos[i - 1].usPerQuarter);
+    }
+  });
+
+  it('produces a continuous (non-stair-step) midiSec curve in the ramp region', () => {
+    const sidecar = generatePlaybackTimeline(score, { tempoRampSteps: 8 });
+    const m2 = sidecar.breakpoints.filter((b) => b.measureNumber === '2');
+    // Many intermediate breakpoints, not just the measure start.
+    expect(m2.length).toBeGreaterThan(2);
+
+    // Strictly increasing midiSec, and the per-step slope keeps growing as the
+    // tempo slows — i.e. the curve bends rather than jumping.
+    const sorted = [...m2].sort((a, b) => a.quarterPos - b.quarterPos);
+    let prevSlope = 0;
+    for (let i = 1; i < sorted.length; i++) {
+      const dSec = sorted[i].midiSec - sorted[i - 1].midiSec;
+      const dQ = sorted[i].quarterPos - sorted[i - 1].quarterPos;
+      const slope = dSec / dQ;
+      expect(slope).toBeGreaterThanOrEqual(prevSlope - 1e-9);
+      prevSlope = slope;
+    }
+  });
+
+  it('labels the ramp span as a rit. expression hint', () => {
+    const sidecar = generatePlaybackTimeline(score, { tempoRampSteps: 8 });
+    expect(sidecar.expressions!.some((e) => e.type === 'rit')).toBe(true);
+  });
+});
+
+describe('tempo map completeness', () => {
+  it('captures all three tempo sources: metronome, direction sound, standalone sound', () => {
+    const score = scoreOf([
+      measure(1, [metronomeDir(100), note()]),
+      measure(2, [soundTempoDir(90), note()]),
+      measure(3, [standaloneSoundTempo(80), note()]),
+    ]);
+    const { tempos } = parseConductor(exportMidi(score));
+    const us = (bpm: number) => Math.round(60000000 / bpm);
+    const values = tempos.map((t) => t.usPerQuarter);
+    expect(values).toContain(us(100));
+    expect(values).toContain(us(90));
+    expect(values).toContain(us(80));
+  });
+});
+
+describe('time-signature changes in the conductor track', () => {
+  it('emits every mid-piece time-signature change, not just the first', () => {
+    const score = scoreOf([
+      measure(1, [note(), note(), note(), note()], ts(4, 4)),
+      measure(2, [note(), note(), note()], ts(3, 4)),
+      measure(3, [note(), note(), note(), note()], ts(4, 4)),
+    ]);
+    const { timeSigs } = parseConductor(exportMidi(score));
+    expect(timeSigs.map((t) => t.numerator)).toEqual([4, 3, 4]);
+    // 4/4 spans 1920 ticks; 3/4 spans 1440.
+    expect(timeSigs.map((t) => t.tick)).toEqual([0, 1920, 1920 + 1440]);
+    // denominator is log2(beatType) = 2 for /4.
+    expect(timeSigs.every((t) => t.denominator === 2)).toBe(true);
+  });
+});
+
+describe('sidecar seconds match real MIDI playback seconds', () => {
+  it('every breakpoint midiSec equals the time computed from the emitted tempo map', () => {
+    // Exercise fractional BPM (ramp) + a fermata so rounding has a chance to drift.
+    const score = scoreOf([
+      measure(1, [metronomeDir(132), note()]),
+      measure(2, [wordsDir('rit.'), note({ fermata: true })]),
+      measure(3, [metronomeDir(76), note()]),
+    ]);
+    const { midi, sidecar } = exportMidiWithTimingMap(score, {
+      tempoRampSteps: 10,
+      fermataHoldMultiplier: 1.8,
+    });
+    const { tempos } = parseConductor(midi);
+
+    for (const bp of sidecar.breakpoints) {
+      const tick = Math.round(bp.quarterPos * TPQN);
+      expect(midiTickToSec(tempos, tick)).toBeCloseTo(bp.midiSec, 6);
+    }
+    // durationSec is the time at the final (terminal) breakpoint.
+    expect(sidecar.durationSec).toBeCloseTo(sidecar.breakpoints.at(-1)!.midiSec, 9);
+  });
+});


### PR DESCRIPTION
## 概要

表現タイミング（フェルマータ・カエスーラ/ブレス・rit./accel.）を、共有 `buildGridTimeline` のテンポマップに畳み込んで実装しました。すべて **方式A**（音価のtickは楽譜どおり固定、時間変化はすべて `set_tempo` で表現）に従い、`durationTicks` の計算には一切触れていません。`tick ÷ tpqn = quarter位置` が常に厳密に成り立ちます。MIDIバイトと timing sidecar は引き続き同一計算から導出されるため、両者の時間軸はズレません。

## 変更点

- **フェルマータ（優先度1）**: フェルマータ音符/休符の **tick区間だけ BPM を下げる局所テンポdip**（BPM ÷ `fermataHoldMultiplier`、既定 1.75）。tick長・`quarterPos` は不変、秒だけ延びる。
- **カエスーラ/ブレス**: 音符の末尾（tail）に短いdipを入れ、設定秒数を挿入。onset位置は動かさない。
- **rit./accel.（優先度2）**: rit/ritard/rall/accel/string 等の `words` を検出し、直前テンポ→次のテンポ指定まで線形ランプを `tempoRampSteps`（既定12）個の細かい `set_tempo` として刻む。sidecar の `midiSec` も同じイベントから算出され、階段状でなく連続カーブに。
- **拍子変化（優先度4）**: conductor track が最初の小節だけでなく、演奏順の **全拍子変化** を `time_signature` メタとして出力。
- **秒の厳密一致**: `makeTickToSec` を conductor track と同じ丸めた usPerQuarter（`bpmToUsPerQuarter`）で積算。ランプの端数BPMでも sidecar の `midiSec` が実MIDI再生秒とマイクロ秒単位で一致。
- **表現ヒント（任意・優先度5）**: sidecar に `expressions: { type, fromMidiSec, toMidiSec }[]`（fermata/caesura/breath/rit/accel）を追加。アライナが区間制約を緩められる。

オプションは共有 `ExpressionOptions`（`fermataHoldMultiplier` / `caesuraSeconds` / `breathSeconds` / `tempoRampSteps`）として `MidiExportOptions` と `TimingMapOptions` の両方に。

## 非目標（据え置き）

- B方式（音価tick伸縮）は採用せず。
- スタッカート/テヌートの note-off 短縮（優先度6・任意）は今回見送り。

## 受け入れ条件の確認

- ✅ フェルマータ区間の `midiSec` が保持倍率どおり延び、`quarterPos` は不変（テンポで延びている）
- ✅ rit./accel. 区間の `midiSec` カーブが連続変化（段差でない）
- ✅ 再パースした MIDI の `set_tempo` が補間後の全テンポ点を含み、`time_signature` 変化が全件含まれる
- ✅ `sidecar.breakpoints` の `midiSec` が同一出力MIDIの実再生秒と一致（回帰テストで固定）
- ✅ 任意の breakpoint で `tick ÷ tpqn == quarterPos`（B方式混入ガード）

## テスト

新規 `tests/midi-expressive-timing.test.ts`（12件）。`tsc --noEmit` クリーン、全体 **968件パス**（既存956 + 新規12）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)