### PR TITLE
fix(midi): 生成MIDIの全長を sidecar.durationSec と一致させる

### DIFF
--- a/src/exporters/midi.ts
+++ b/src/exporters/midi.ts
@@ -337,8 +337,16 @@ function createConductorTrack(
     lastTick = ev.tick;
   }
 
-  // End of track
-  events.push(...writeVariableLength(0), 0xff, 0x2f, 0x00);
+  // End of track extended to the timeline end (grid.totalTicks), so the MIDI
+  // file's total length equals tickToSec(totalTicks) == sidecar.durationSec
+  // even when the final measure ends in a rest (or a fermata note that releases
+  // before the barline). The trailing span is silence — no note is added; this
+  // keeps the conductor track (the timeline master) as long as the grid and
+  // therefore at least as long as every part track.
+  events.push(
+    ...writeVariableLength(Math.max(0, grid.totalTicks - lastTick)),
+    0xff, 0x2f, 0x00
+  );
 
   return new Uint8Array(events);
 }

--- a/tests/midi-expressive-timing.test.ts
+++ b/tests/midi-expressive-timing.test.ts
@@ -85,6 +85,8 @@ function scoreOf(measures: Measure[]): Score {
 interface ConductorEvents {
   tempos: { tick: number; usPerQuarter: number }[];
   timeSigs: { tick: number; numerator: number; denominator: number }[];
+  /** Tick of the conductor track's end_of_track meta event. */
+  endTick: number;
 }
 
 function parseConductor(data: Uint8Array): ConductorEvents {
@@ -97,7 +99,7 @@ function parseConductor(data: Uint8Array): ConductorEvents {
   const bodyStart = pos + 8;
   const bodyEnd = bodyStart + len;
 
-  const ev: ConductorEvents = { tempos: [], timeSigs: [] };
+  const ev: ConductorEvents = { tempos: [], timeSigs: [], endTick: 0 };
   let i = bodyStart;
   let tick = 0;
   const readVarLen = () => {
@@ -123,6 +125,8 @@ function parseConductor(data: Uint8Array): ConductorEvents {
         });
       } else if (metaType === 0x58 && metaLen === 4) {
         ev.timeSigs.push({ tick, numerator: data[i], denominator: data[i + 1] });
+      } else if (metaType === 0x2f) {
+        ev.endTick = tick;
       }
       i += metaLen;
     } else {
@@ -131,6 +135,56 @@ function parseConductor(data: Uint8Array): ConductorEvents {
     }
   }
   return ev;
+}
+
+/** Maximum end-tick across all tracks (= the MIDI file's total length in ticks). */
+function maxTrackEndTick(data: Uint8Array): number {
+  let pos = 14;
+  const u32 = (p: number) =>
+    (data[p] << 24) | (data[p + 1] << 16) | (data[p + 2] << 8) | data[p + 3];
+  let maxTick = 0;
+  while (pos < data.length) {
+    const len = u32(pos + 4);
+    let i = pos + 8;
+    const end = i + len;
+    let tick = 0;
+    let running = 0;
+    const readVarLen = () => {
+      let value = 0;
+      for (;;) {
+        const byte = data[i++];
+        value = (value << 7) | (byte & 0x7f);
+        if (!(byte & 0x80)) break;
+      }
+      return value;
+    };
+    while (i < end) {
+      tick += readVarLen();
+      let status = data[i];
+      if (status & 0x80) {
+        i++;
+        running = status;
+      } else {
+        status = running;
+      }
+      if (status === 0xff) {
+        i++; // meta type
+        const metaLen = readVarLen();
+        i += metaLen;
+      } else if ((status & 0xf0) === 0xc0 || (status & 0xf0) === 0xd0) {
+        i += 1;
+      } else {
+        i += 2;
+      }
+    }
+    if (tick > maxTick) maxTick = tick;
+    pos = end;
+  }
+  return maxTick;
+}
+
+function rest(duration = 4): NoteEntry {
+  return { _id: id(), type: 'note', rest: {}, duration, voice: '1' };
 }
 
 /** Tick → seconds using the parsed (piecewise-constant) MIDI tempo map. */
@@ -327,5 +381,45 @@ describe('sidecar seconds match real MIDI playback seconds', () => {
     }
     // durationSec is the time at the final (terminal) breakpoint.
     expect(sidecar.durationSec).toBeCloseTo(sidecar.breakpoints.at(-1)!.midiSec, 9);
+  });
+});
+
+describe('MIDI total length matches sidecar.durationSec', () => {
+  it("extends end_of_track to the grid end when the final measure ends in a rest", () => {
+    // m2 = half note + half rest: notes stop at tick 2880, but the measure (and
+    // the grid) runs to tick 3840. Without padding, the file would end early.
+    const score = scoreOf([
+      measure(1, [note()]),
+      measure(2, [note({ duration: 2 }), rest(2)]),
+    ]);
+    const { midi, sidecar } = exportMidiWithTimingMap(score);
+    const { tempos, endTick } = parseConductor(midi);
+
+    // Conductor end_of_track sits at the grid end (3840 ticks), not the last note.
+    expect(endTick).toBe(3840);
+    // File length (max track end) converted to seconds equals durationSec.
+    const fileSec = midiTickToSec(tempos, maxTrackEndTick(midi));
+    expect(fileSec).toBeCloseTo(sidecar.durationSec, 3); // within 1 ms
+  });
+
+  it('matches even when a fermata note releases before the barline', () => {
+    // m2: fermata half note then half rest. The fermata stretches the first
+    // half (tempo dip); the trailing rest still has to be reached at the grid end.
+    const score = scoreOf([
+      measure(1, [note()]),
+      measure(2, [note({ duration: 2, fermata: true }), rest(2)]),
+    ]);
+    const { midi, sidecar } = exportMidiWithTimingMap(score, { fermataHoldMultiplier: 2 });
+    const { tempos } = parseConductor(midi);
+    const fileSec = midiTickToSec(tempos, maxTrackEndTick(midi));
+    expect(fileSec).toBeCloseTo(sidecar.durationSec, 3);
+  });
+
+  it('still matches for a plain score with no trailing rest', () => {
+    const score = scoreOf([measure(1, [note()]), measure(2, [note()])]);
+    const { midi, sidecar } = exportMidiWithTimingMap(score);
+    const { tempos } = parseConductor(midi);
+    const fileSec = midiTickToSec(tempos, maxTrackEndTick(midi));
+    expect(fileSec).toBeCloseTo(sidecar.durationSec, 3);
   });
 });


### PR DESCRIPTION
## 問題

`exportMidiWithTimingMap` で、`sidecar.durationSec`（= `tickToSec(grid.totalTicks)`）が生成MIDIファイルの実全長より長いケースがあった。

- 例(Pavane): 最終 note_off ≈ 316.556s でMIDIファイルが終わる一方、`sidecar.durationSec` = 319.222s（最終小節の残り拍/休符を含む）。
- 差分は「最終小節の最後の音符以降（休符ぶん）」。MIDIにはそこにイベントが無く、ファイルが早く終わる。

### 影響
- aligner は MIDI全長（316.556s）までしかアンカーを張れない。
- ScoreTail は `durationSec`（319.222s）を曲末とするため、末尾で再生バーが固着/クランプする。
- 不変条件「`TimingBreakpoint.midiSec` / `durationSec` は実MIDI時刻に等しい」が末尾でだけ破れていた。

## 原因

`createConductorTrack` / `createPartTrack` は最後のイベント直後に `end_of_track` を出すだけで、`grid.totalTicks` まで延ばしていなかった。一方 `buildTimingSidecar` は `durationSec = tickToSec(grid.totalTicks)`。両者の終端定義が食い違っていた。

## 修正

コンダクタトラック（タイムラインの主）の `end_of_track` を `grid.totalTicks` まで延長（最後の発行tickから `grid.totalTicks - lastTick` ぶんの delta を入れる）。

```ts
events.push(
  ...writeVariableLength(Math.max(0, grid.totalTicks - lastTick)),
  0xff, 0x2f, 0x00
);
```

末尾の休符ぶんは合成では無音として描画される（音楽的に正しい）。コンダクタトラックは常にグリッド終端と同じ長さになるため、どのパートトラック以上の長さが保証され、ファイル全長 = `grid.totalTicks` = `sidecar.durationSec` になる。

## 受け入れ条件

- ✅ 生成MIDIを再パースした全長（最大トラック `end_of_track` の秒）が `sidecar.durationSec` と一致（±1ms）
- ✅ 最終小節末に休符がある譜でも一致
- ✅ フェルマータ音符が小節末より早く切れる譜でも一致

## 非目標（維持）

- 音符長/note-off の意味は変えない（休符ぶんを音で埋めない）。`end_of_track` を伸ばすだけ。
- MIDI と sidecar の共有計算（`buildGridTimeline`）は維持。

## テスト

`tests/midi-expressive-timing.test.ts` に3件追加（末尾休符 / フェルマータ＋末尾休符 / 末尾休符なし）。全体 **971件パス**、`tsc --noEmit` クリーン。

> 注: 本修正は当初誤って main へ直接プッシュしてしまったため、main を v0.7.2(efcc3bc) に巻き戻し、本ブランチに切り出してこのPRにしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)