### PR TITLE
fix(timeline): 過充填小節を拍子ではなく実内容で長さ確定（m71→m72の重なり解消）

### DIFF
--- a/src/query/playback-timeline.ts
+++ b/src/query/playback-timeline.ts
@@ -228,8 +228,18 @@ function findTimeSignature(
 
 /**
  * Absolute tick at the end of a measure, given where it started.
- * Implicit (pickup) measures use their actual content length; regular
- * measures use the time signature but never exceed their actual content.
+ *
+ * The measure spans its ACTUAL notated content whenever it has any: implicit
+ * (pickup) and incomplete measures come out shorter than the meter, and
+ * over-full measures come out longer. The latter is the irregular case that
+ * matters for alignment — e.g. a written-out arpeggiated roll (cue notes with
+ * real durations, tied into the chord that follows) pushes a 4/4 bar past four
+ * beats. Clamping such a bar back to the time signature would drop the overflow
+ * onto the next measure's downbeat (two onsets colliding at one tick); honoring
+ * the content instead lets the next measure begin cleanly after it.
+ *
+ * The time signature is only a fallback for measures with no timed content at
+ * all (e.g. a bar carrying only directions), so an empty bar still advances.
  */
 export function measureEndTick(
   measure: Measure,
@@ -241,21 +251,22 @@ export function measureEndTick(
 ): number {
   const actualTicks = Math.round((maxPosition * ticksPerQuarterNote) / divisions);
 
-  if (measure.implicit) {
+  if (actualTicks > 0) {
     return measureStartTick + actualTicks;
   }
 
-  const timeAttrs = findTimeSignature(part, measure.number);
-  if (timeAttrs) {
-    const measureDuration = (timeAttrs.beats / timeAttrs.beatType) * 4 * divisions;
-    const calculatedTicks = Math.round((measureDuration * ticksPerQuarterNote) / divisions);
-    // Use the smaller of calculated and actual for incomplete measures
-    // (e.g., last measure before a repeat that combines with a pickup).
-    const ticksToAdd = Math.min(calculatedTicks, actualTicks > 0 ? actualTicks : calculatedTicks);
-    return measureStartTick + ticksToAdd;
+  // No timed content: fall back to the time-signature length so the bar still
+  // occupies its meter (implicit pickups with no content simply add nothing).
+  if (!measure.implicit) {
+    const timeAttrs = findTimeSignature(part, measure.number);
+    if (timeAttrs) {
+      const measureDuration = (timeAttrs.beats / timeAttrs.beatType) * 4 * divisions;
+      const calculatedTicks = Math.round((measureDuration * ticksPerQuarterNote) / divisions);
+      return measureStartTick + calculatedTicks;
+    }
   }
 
-  return measureStartTick + actualTicks;
+  return measureStartTick;
 }
 
 /** Does this note/rest carry a fermata notation? */

--- a/tests/midi-expressive-timing.test.ts
+++ b/tests/midi-expressive-timing.test.ts
@@ -347,10 +347,11 @@ describe('tempo map completeness', () => {
 
 describe('time-signature changes in the conductor track', () => {
   it('emits every mid-piece time-signature change, not just the first', () => {
+    // divisions=1 → duration 1 is one quarter; fill each bar to its meter.
     const score = scoreOf([
-      measure(1, [note(), note(), note(), note()], ts(4, 4)),
-      measure(2, [note(), note(), note()], ts(3, 4)),
-      measure(3, [note(), note(), note(), note()], ts(4, 4)),
+      measure(1, [note({ duration: 1 }), note({ duration: 1 }), note({ duration: 1 }), note({ duration: 1 })], ts(4, 4)),
+      measure(2, [note({ duration: 1 }), note({ duration: 1 }), note({ duration: 1 })], ts(3, 4)),
+      measure(3, [note({ duration: 1 }), note({ duration: 1 }), note({ duration: 1 }), note({ duration: 1 })], ts(4, 4)),
     ]);
     const { timeSigs } = parseConductor(exportMidi(score));
     expect(timeSigs.map((t) => t.numerator)).toEqual([4, 3, 4]);
@@ -358,6 +359,79 @@ describe('time-signature changes in the conductor track', () => {
     expect(timeSigs.map((t) => t.tick)).toEqual([0, 1920, 1920 + 1440]);
     // denominator is log2(beatType) = 2 for /4.
     expect(timeSigs.every((t) => t.denominator === 2)).toBe(true);
+  });
+});
+
+/** All note-on ticks across every part track (track 0 is the conductor). */
+function noteOnTicks(data: Uint8Array): number[] {
+  let pos = 14;
+  const u32 = (p: number) =>
+    (data[p] << 24) | (data[p + 1] << 16) | (data[p + 2] << 8) | data[p + 3];
+  const ticks: number[] = [];
+  while (pos < data.length) {
+    const len = u32(pos + 4);
+    let i = pos + 8;
+    const end = i + len;
+    let tick = 0;
+    let running = 0;
+    const readVarLen = () => {
+      let value = 0;
+      for (;;) {
+        const byte = data[i++];
+        value = (value << 7) | (byte & 0x7f);
+        if (!(byte & 0x80)) break;
+      }
+      return value;
+    };
+    while (i < end) {
+      tick += readVarLen();
+      let status = data[i];
+      if (status & 0x80) {
+        i++;
+        running = status;
+      } else {
+        status = running;
+      }
+      if (status === 0xff) {
+        i++;
+        const metaLen = readVarLen();
+        i += metaLen;
+      } else if ((status & 0xf0) === 0x90) {
+        i++; // note
+        const vel = data[i++];
+        if (vel > 0) ticks.push(tick);
+      } else if ((status & 0xf0) === 0x80) {
+        i += 2;
+      } else if ((status & 0xf0) === 0xc0 || (status & 0xf0) === 0xd0) {
+        i += 1;
+      } else {
+        i += 2;
+      }
+    }
+    pos = end;
+  }
+  return ticks;
+}
+
+describe('over-full measure honors its content (no collision into the next bar)', () => {
+  // Mirrors the Ravel Pavane m71: a 4/4 bar whose notated content is 5 quarters
+  // (a written-out arpeggiated roll pushes the bar past the meter). The bar must
+  // span 5 quarters so the final note does not land on the next downbeat.
+  const score = scoreOf([
+    measure(1, [note({ duration: 1 }), note({ duration: 1, step: 'D' }), note({ duration: 1, step: 'E' }), note({ duration: 1, step: 'F' }), note({ duration: 1, step: 'G' })], ts(4, 4)),
+    measure(2, [note({ duration: 1, step: 'A' })], ts(4, 4)),
+  ]);
+
+  it('places the next measure after the full content, not clamped to the meter', () => {
+    const sidecar = generatePlaybackTimeline(score);
+    const m2 = sidecar.breakpoints.find((b) => b.measureNumber === '2' && b.beatInMeasure === 0)!;
+    expect(m2.quarterPos).toBe(5); // 5 quarters of content, not clamped to 4
+  });
+
+  it("does not collide the bar's last onset with the next bar's downbeat", () => {
+    const ticks = noteOnTicks(exportMidi(score)).sort((a, b) => a - b);
+    // 6 distinct onsets at 0,480,960,1440,1920 (m1) and 2400 (m2) — all unique.
+    expect(ticks).toEqual([0, 480, 960, 1440, 1920, 2400]);
   });
 });
 


### PR DESCRIPTION
## 問題

Ravel「パヴァーヌ」71小節目で、最終音符（5拍目の D4）と72小節目の頭の音が **同じtick（同時刻）に重なって** 生成されていた。

### 原因
71小節目は拍子上 4/4 だが、上行アルペジオ（`cue` サイズだが実 `<duration>` を持ち、後続の和音にタイで繋がる「書き出されたロール」）のぶん、記譜内容が **5拍** ある（divisions=240 で内容 1200 = 5四分）。

`measureEndTick` は `Math.min(calculatedTicks, actualTicks)` で小節長を拍子にクランプしていたため、過充填小節（内容＞拍子）が 4拍に切り詰められ、5拍目の onset が次小節の頭tickに落ちて衝突していた。

確認（修正前）:
```
grid m#71 start=131520 end=133440 span=4q   ← 内容5拍なのに4拍に切詰
grid m#72 start=133440 ...                  ← D4(133440) と m72頭(133440) が同時
```

## 修正

小節に実内容がある限り **実内容（actualTicks）で長さを確定** する。
- 不完全/アウフタクト小節 → 従来どおり短いまま（`min` 時代と同じ結果）
- 過充填小節 → 内容ぶん長く取り、次小節は内容の後ろから開始（衝突しない）
- 拍子は「タイム情報を持つ音符が無い小節（ディレクションのみ等）」のフォールバックとしてのみ使用

MIDI（`createPartTrack`）と sidecar（`buildGridTimeline`）は両方 `measureEndTick` を通るため整合は保たれる。

確認（修正後）:
```
grid m#71 start=131520 end=133920 span=5q
grid m#72 start=133920 ...                  ← D4(133440) と m72頭(133920) は別tick
bp m#72 beat0 quarterPos=279 (was 278)
```

## 受け入れ条件

- ✅ 過充填小節が実内容ぶんの長さになり、次小節がその後ろから始まる（拍子クランプしない）
- ✅ 小節最後の onset が次小節頭と衝突しない（onset が全て別tick）
- ✅ 不完全小節・空小節・通常小節の挙動は不変（既存テスト維持）

## テスト

`tests/midi-expressive-timing.test.ts` に過充填小節のリグレッションテストを追加（m71を模した 4/4 内 5拍 → 次小節 quarterPos=5、onset 衝突なし）。あわせて拍子変化テストの音価を実拍に合わせて修正（旧クランプ挙動に依存していたため）。全体 **973件パス**、`tsc --noEmit` クリーン。

> 楽譜どおり再生すると 71小節目は実際に 5拍あり、本修正はそれを受け入れた上で 72小節目が時間的に滑らかに繋がるようにするもの。

🤖 Generated with [Claude Code](https://claude.com/claude-code)