### PR TITLE
Add fan attribute support to BeamInfo for feathered beams

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -285,6 +285,7 @@ interface TieInfo {
 interface BeamInfo {
   number: number;                // 1, 2, ... (連桁レベル)
   type: 'begin' | 'continue' | 'end' | 'forward hook' | 'backward hook';
+  fan?: 'accel' | 'rit' | 'none'; // <beam> fan 属性（羽根状連桁）
 }
 
 // ============================================================

--- a/src/exporters/musicxml.ts
+++ b/src/exporters/musicxml.ts
@@ -1085,7 +1085,8 @@ function serializePitch(pitch: Pitch, indent: string, out: string[]): void {
 }
 
 function serializeBeam(beam: BeamInfo, indent: string, out: string[]): void {
-  out.push(`${indent}<beam number="${beam.number}">${beam.type}</beam>`);
+  const fanAttr = beam.fan ? ` fan="${beam.fan}"` : '';
+  out.push(`${indent}<beam number="${beam.number}"${fanAttr}>${beam.type}</beam>`);
 }
 
 function serializeNotations(notations: Notation[], indent: string, out: string[]): void {

--- a/src/importers/musicxml.ts
+++ b/src/importers/musicxml.ts
@@ -1386,10 +1386,15 @@ function parsePitch(elements: XmlChild[]): Pitch {
 function parseBeam(elements: XmlChild[], attrs: Record<string, string>): BeamInfo {
   const text = extractText(elements);
   const validTypes = ['begin', 'continue', 'end', 'forward hook', 'backward hook'];
-  return {
+  const validFans = ['accel', 'rit', 'none'];
+  const beam: BeamInfo = {
     number: parseInt(attrs['number'] || '1', 10),
     type: validTypes.includes(text) ? text as BeamInfo['type'] : 'begin',
   };
+  if (attrs['fan'] && validFans.includes(attrs['fan'])) {
+    beam.fan = attrs['fan'] as BeamInfo['fan'];
+  }
+  return beam;
 }
 
 function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notation[] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -627,6 +627,8 @@ export interface TieInfo {
 export interface BeamInfo {
   number: number;
   type: 'begin' | 'continue' | 'end' | 'forward hook' | 'backward hook';
+  /** MusicXML <beam> fan attribute, used for feathered beams (羽根状連桁). */
+  fan?: 'accel' | 'rit' | 'none';
 }
 
 // ============================================================

--- a/tests/serializer.test.ts
+++ b/tests/serializer.test.ts
@@ -66,6 +66,43 @@ describe('Serializer', () => {
     expect(xml).toContain('</score-partwise>');
   });
 
+  it('should serialize and round-trip beam fan attribute (feathered beam)', () => {
+    const score: Score = {
+      metadata: {},
+      partList: [{ type: 'score-part', id: 'P1', name: 'Piano' }],
+      parts: [
+        {
+          id: 'P1',
+          measures: [
+            {
+              number: 1,
+              attributes: { divisions: 1 },
+              entries: [
+                {
+                  type: 'note',
+                  pitch: { step: 'C', octave: 4 },
+                  duration: 1,
+                  voice: '1',
+                  noteType: 'eighth',
+                  beam: [{ number: 1, type: 'begin', fan: 'accel' }],
+                } as NoteEntry,
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const xml = serialize(score);
+    expect(xml).toContain('<beam number="1" fan="accel">begin</beam>');
+
+    const reparsed = parse(xml);
+    const note = reparsed.parts[0].measures[0].entries.find(
+      (e) => e.type === 'note'
+    ) as NoteEntry;
+    expect(note.beam?.[0].fan).toBe('accel');
+  });
+
   it('should serialize a chord', () => {
     const score: Score = {
       metadata: {},


### PR DESCRIPTION
## 概要

`<beam>` 要素の `fan` 属性（羽根状連桁 / feathered beam の描画に必要）を保持するように対応しました。これまではパース時に破棄されており、`beam` 配列の各要素から取得できませんでした。

## 変更内容

- **`BeamInfo` インターフェース** (`src/types.ts`): `fan?: 'accel' | 'rit' | 'none'` フィールドを追加
- **インポーター** (`src/importers/musicxml.ts`): `parseBeam` で `fan` 属性をパース（有効な値域 `accel` / `rit` / `none` のみ採用）
- **エクスポーター** (`src/exporters/musicxml.ts`): `serializeBeam` で `fan` 属性を出力（存在する場合のみ）
- **SPEC.md**: `BeamInfo` のドキュメントを更新
- **テスト** (`tests/serializer.test.ts`): fan 属性のシリアライズ・ラウンドトリップを検証するテストを追加

## テスト

全 974 テストがパスすることを確認済み。

https://claude.ai/code/session_01TTXsUGYKGiDCFSBCJdt1RY

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTXsUGYKGiDCFSBCJdt1RY)_