### PR TITLE
Add credit-image parse/serialize support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- `<credit-image>` support: credit images are now parsed into `credit.creditImage` and serialized back to MusicXML. The `CreditImage` type covers the full MusicXML image attribute set (`source`, `type`, `height`, `width`, `default-x/y`, `relative-x/y`, `halign`, `valign`). Previously the field existed on the `Credit` type but was silently dropped on both parse and serialize. `CreditImage` and `CreditWords` are now exported from the package root.
+
 ### Performance
 - MusicXML parsing is ~1.45x faster. The txml dependency was replaced with a built-in parser specialized for MusicXML that skips pretty-printing whitespace nodes at scan time, decodes entities inline (no second pass over the tree), and handles processing instructions natively (no regex preprocessing). Node.js additionally gets a faster `Buffer` → string decode path.
 - Bundle size: importing only `parse` now costs ~47 KB minified / ~13 KB gzipped (was ~49 KB / ~14 KB); the txml dependency is gone.

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -36,6 +36,8 @@ export type {
   Print,
   Defaults,
   Credit,
+  CreditWords,
+  CreditImage,
   // Extended Query Types
   VoiceToStaffMap,
   NoteWithContext,

--- a/src/exporters/musicxml.ts
+++ b/src/exporters/musicxml.ts
@@ -407,6 +407,20 @@ function serializeCredit(credit: Credit, indent: string, out: string[]): void {
     }
   }
 
+  if (credit.creditImage) {
+    const ci = credit.creditImage;
+    let attrs = ` source="${escapeXml(ci.source)}" type="${escapeXml(ci.type)}"`;
+    if (ci.height !== undefined) attrs += ` height="${ci.height}"`;
+    if (ci.width !== undefined) attrs += ` width="${ci.width}"`;
+    if (ci.defaultX !== undefined) attrs += ` default-x="${ci.defaultX}"`;
+    if (ci.defaultY !== undefined) attrs += ` default-y="${ci.defaultY}"`;
+    if (ci.relativeX !== undefined) attrs += ` relative-x="${ci.relativeX}"`;
+    if (ci.relativeY !== undefined) attrs += ` relative-y="${ci.relativeY}"`;
+    if (ci.halign) attrs += ` halign="${escapeXml(ci.halign)}"`;
+    if (ci.valign) attrs += ` valign="${escapeXml(ci.valign)}"`;
+    out.push(`${indent}${indent}<credit-image${attrs}/>`);
+  }
+
   if (credit.creditWords) {
     for (const cw of credit.creditWords) {
       let attrs = '';

--- a/src/importers/musicxml.ts
+++ b/src/importers/musicxml.ts
@@ -34,6 +34,7 @@ import type {
   Defaults,
   Credit,
   CreditWords,
+  CreditImage,
   RestInfo,
   NoteheadInfo,
   NoteheadValue,
@@ -807,8 +808,21 @@ function parseCredits(elements: XmlChild[]): Credit[] | undefined {
       if (a['xml:space']) cw.xmlSpace = a['xml:space'];
       return cw;
     });
+    const images = collectElements(content, 'credit-image', (_c, a) => {
+      const ci: CreditImage = { source: a['source'] || '', type: a['type'] || '' };
+      if (a['height']) ci.height = parseFloat(a['height']);
+      if (a['width']) ci.width = parseFloat(a['width']);
+      if (a['default-x']) ci.defaultX = parseFloat(a['default-x']);
+      if (a['default-y']) ci.defaultY = parseFloat(a['default-y']);
+      if (a['relative-x']) ci.relativeX = parseFloat(a['relative-x']);
+      if (a['relative-y']) ci.relativeY = parseFloat(a['relative-y']);
+      if (a['halign']) ci.halign = a['halign'];
+      if (a['valign']) ci.valign = a['valign'];
+      return ci;
+    });
     if (types.length > 0) credit.creditType = types;
     if (words.length > 0) credit.creditWords = words;
+    if (images.length > 0) credit.creditImage = images[0];
     return credit;
   });
   return credits.length > 0 ? credits : undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,7 +120,20 @@ export interface Credit {
   page?: number;
   creditType?: string[];
   creditWords?: CreditWords[];
-  creditImage?: { source: string; type: string; height?: number; width?: number };
+  creditImage?: CreditImage;
+}
+
+export interface CreditImage {
+  source: string;
+  type: string;
+  height?: number;
+  width?: number;
+  defaultX?: number;
+  defaultY?: number;
+  relativeX?: number;
+  relativeY?: number;
+  halign?: string;
+  valign?: string;
 }
 
 export interface CreditWords {

--- a/tests/serializer.test.ts
+++ b/tests/serializer.test.ts
@@ -397,4 +397,92 @@ describe('Serializer', () => {
     expect(xml).toContain(`<measure number="1" id="${measure._id}"`);
     expect(xml).toContain(`<note id="${note._id}"`);
   });
+
+  it('should serialize credit-image', () => {
+    const score: Score = {
+      metadata: {},
+      partList: [{ type: 'score-part', id: 'P1', name: 'Piano' }],
+      parts: [{ id: 'P1', measures: [] }],
+      credits: [
+        {
+          _id: 'credit1',
+          page: 1,
+          creditType: ['logo'],
+          creditImage: {
+            source: 'logo.png',
+            type: 'image/png',
+            height: 30,
+            width: 120,
+            defaultX: 70,
+            defaultY: 1650,
+            halign: 'left',
+            valign: 'top',
+          },
+        },
+      ],
+    };
+
+    const xml = serialize(score);
+
+    expect(xml).toContain(
+      '<credit-image source="logo.png" type="image/png" height="30" width="120" default-x="70" default-y="1650" halign="left" valign="top"/>'
+    );
+  });
+
+  it('should preserve credit-image through parse-serialize roundtrip', () => {
+    const inputXml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <credit page="1">
+    <credit-type>logo</credit-type>
+    <credit-image source="logo.png" type="image/png" height="30" width="120" default-x="70" default-y="1650" relative-x="5" relative-y="-5" halign="left" valign="top"/>
+  </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Test</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    const score = parse(inputXml);
+
+    expect(score.credits).toHaveLength(1);
+    const credit = score.credits![0];
+    expect(credit.page).toBe(1);
+    expect(credit.creditType).toEqual(['logo']);
+    expect(credit.creditImage).toEqual({
+      source: 'logo.png',
+      type: 'image/png',
+      height: 30,
+      width: 120,
+      defaultX: 70,
+      defaultY: 1650,
+      relativeX: 5,
+      relativeY: -5,
+      halign: 'left',
+      valign: 'top',
+    });
+
+    const xml = serialize(score);
+    expect(xml).toContain(
+      '<credit-image source="logo.png" type="image/png" height="30" width="120" default-x="70" default-y="1650" relative-x="5" relative-y="-5" halign="left" valign="top"/>'
+    );
+
+    // Reparse to verify full roundtrip stability
+    const reparsed = parse(xml);
+    expect(reparsed.credits![0].creditImage).toEqual(credit.creditImage);
+  });
 });


### PR DESCRIPTION
## Summary

The `creditImage` field existed on the `Credit` type but was silently dropped on both parse and serialize — `<credit-image>` elements were lost in every roundtrip. This PR implements full support:

- **Importer**: `<credit-image>` inside `<credit>` is now parsed into `credit.creditImage`.
- **Types**: `CreditImage` is now a named exported interface covering the full MusicXML image attribute set: `source`, `type`, `height`, `width`, `defaultX`, `defaultY`, `relativeX`, `relativeY`, `halign`, `valign` (previously only `source`/`type`/`height`/`width` as an inline type).
- **Exporter**: `credit.creditImage` is serialized as a self-closing `<credit-image .../>` element, placed after `<credit-type>` and before `<credit-words>` per the MusicXML schema order.
- **Exports**: `CreditImage` and `CreditWords` are now exported from the package root (previously only `Credit` was).
- CHANGELOG entry added under Unreleased.

## Tests

- New serializer test for `credit-image` attribute output.
- New parse → serialize → reparse roundtrip test verifying all attributes (including `relative-x`/`relative-y`) survive intact.
- Full suite: 1028 tests pass, `tsc --noEmit` clean, lint has no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkKqNpzkDEaoddmnwGwDbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkKqNpzkDEaoddmnwGwDbr)_