### PR TITLE
Support the MusicXML color attribute on every modelled element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 ## [Unreleased]
 
 ### Added
+- **Full MusicXML `color` support.** The `color` attribute now round-trips on every element the `Score` model represents, not just `<accidental>` and `<words>`. Newly carried through:
+  - Notes and their parts — `<note>`, `<type>`, `<dot>`, `<stem>`, `<notehead>`, `<beam>`.
+  - Every `<notations>` child — ties, slurs, articulations, ornaments (including `<accidental-mark>`, `<wavy-line>`, `<tremolo>`), technicals, dynamics, fermatas, arpeggios, glissandi and slides. `<tuplet>` is the one notation element with no `color` attribute in the MusicXML schema, so a colour set there is not written out.
+  - Lyrics — `<lyric>`, each `<text>` (including across elisions), and `<extend>`.
+  - Every `<direction-type>` child that has a `color` attribute: dynamics, wedges, metronome, rehearsal, segno, coda, pedal, octave-shift, bracket, dashes, accordion-registration, eyeglasses, damp, damp-all, scordatura, harp-pedals and other-direction. `<image>` and `<swing>` have none.
+  - `<harmony>`, `<kind>`, `<frame>` and `<figured-bass>` (with its `<extend>`).
+  - `<key>`, `<time>`, `<clef>`, `<measure-style>`, `<bar-style>` and `<ending>`.
+  - `<part-name>`, `<part-abbreviation>`, `<group-name>`, `<group-abbreviation>`, `<group-symbol>`, `<display-text>` and `<credit-words>`.
+
+  Colours were previously dropped on parse and never emitted on serialize, so a coloured score came back monochrome.
+- `setColor(score, options)` and `clearColors(score)` operations for changing colours. `setColor` selects by part index or ID, measure number, a note predicate, and a list of element kinds (`ColorTarget`, with `ALL_COLOR_TARGETS` exported for "everything"); passing `color: null` removes a colour. `clearColors` strips every colour in a score, including the part-list and credit colours `setColor`'s targets do not cover. Both return a new `Score` and leave the input untouched. See [OPERATIONS.md](OPERATIONS.md#color-operations).
+- New exported type `Color` (the MusicXML `#RRGGBB` / `#AARRGGBB` string), plus `NoteheadInfo`, `StemInfo`, `AccidentalMarkInfo`, `LyricTextElement`, `DisplayText`, `HarmonyEntry`, `HarmonyFrame`, `FiguredBassEntry` and `MeasureStyle`, which colour-editing code needs to name.
 - Much broader ABC notation coverage, targeting the ABC standard v2.1. Newly supported:
   - **Decorations** — the single-character shorthand set (`. ~ H L M O P S T u v`), the `!name!` long form and the deprecated `+name+` form now map onto real MusicXML articulations, ornaments, technicals, fermatas, hairpins and navigation marks instead of being carried as opaque `<words>`. Decorations with no MusicXML counterpart keep their ABC text.
   - **Text annotations** — `"^above"`, `"_below"`, `"<"`, `">"` and `"@"` become `<direction><words>` with the matching placement. They were previously dropped, and mistaken for chord symbols.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -280,6 +280,97 @@ Piano Roll style note manipulation.
 
 ---
 
+## Color Operations
+
+Unlike the operations above, these return a `Score` directly rather than an
+`OperationResult<Score>` — a colour change cannot make a score musically
+invalid, so there is nothing to fail on. Like every operation, they leave the
+input score untouched.
+
+| Operation | Description |
+|-----------|-------------|
+| `setColor` | Set (or clear, with `color: null`) the colour of selected score elements |
+| `clearColors` | Remove every colour in the score |
+
+### `setColor(score, options)`
+
+```typescript
+interface SetColorOptions {
+  color: Color | null;          // '#RRGGBB' / '#AARRGGBB', or null to remove
+  targets?: ColorTarget[];      // default: ['note']
+  partIndices?: number[];       // default: every part
+  partIds?: string[];           // default: every part
+  measureNumbers?: (string | number)[];  // default: every measure
+  noteFilter?: (note: NoteEntry) => boolean;
+}
+```
+
+`ColorTarget` is one of:
+
+| Target | MusicXML element |
+|--------|------------------|
+| `note` | `<note>` — the whole note (head, stem, flags, dots) |
+| `notehead` | `<notehead>` |
+| `stem` | `<stem>` |
+| `beam` | `<beam>` |
+| `accidental` | `<accidental>` |
+| `dot` | `<dot>` |
+| `noteType` | `<type>` |
+| `notation` | every element inside `<notations>` except `<tuplet>` |
+| `lyric` | `<lyric>` and its `<text>` elements |
+| `direction` | every `<direction-type>` child except `<image>` and `<swing>` |
+| `harmony` | `<harmony>`, `<kind>`, `<frame>` |
+| `figuredBass` | `<figured-bass>` |
+| `clef` | `<clef>` |
+| `key` | `<key>` |
+| `time` | `<time>` |
+| `barline` | `<bar-style>` and `<ending>` |
+
+`ALL_COLOR_TARGETS` is exported for "colour everything" cases. The
+finer-grained note targets colour a single child element, which overrides the
+`note` colour for that part of the note only.
+
+`noteFilter` applies to the note targets (`note`, `notehead`, `stem`, `beam`,
+`accidental`, `dot`, `noteType`, `notation`, `lyric`); the other targets are
+unaffected by it.
+
+```typescript
+import { setColor, clearColors, ALL_COLOR_TARGETS } from 'musicxml-io';
+
+// Every note in measures 5-6 of the first part, red
+const marked = setColor(score, {
+  color: '#FF0000',
+  partIndices: [0],
+  measureNumbers: [5, 6],
+});
+
+// One note plus its stem and beams
+const highlighted = setColor(score, {
+  color: '#0000FF',
+  targets: ['note', 'stem', 'beam'],
+  noteFilter: (n) => n._id === noteId,
+});
+
+// Colour everything, then take it all back off
+const rainbow = setColor(score, { color: '#008000', targets: [...ALL_COLOR_TARGETS] });
+const plain = clearColors(rainbow);
+```
+
+`clearColors` reaches further than `setColor(score, { color: null, ... })`: it
+also strips colours the targets do not cover, such as part names, group names,
+credit words and `<display-text>`.
+
+Elements not covered by a `ColorTarget` still round-trip their colour and can
+be set by writing the field directly — colour is an ordinary property on the
+Score model:
+
+```typescript
+score.partList[0].nameColor = '#FF0000';        // <part-name color="...">
+score.credits![0].creditWords![0].color = '#FF0000';
+```
+
+---
+
 ## Copy / Paste Operations
 
 | Operation | Description |

--- a/README.md
+++ b/README.md
@@ -221,6 +221,64 @@ for (const entry of measure.entries) {
 }
 ```
 
+### Color
+
+MusicXML's `color` attribute is supported on every element the `Score` model
+represents. Colours survive a parse → serialize round-trip, and can be read or
+written as an ordinary property:
+
+```typescript
+import { parse, setColor, clearColors, ALL_COLOR_TARGETS } from 'musicxml-io';
+
+const score = parse(xmlString);
+
+// Every note of measures 5-6 in the first part, red
+const marked = setColor(score, {
+  color: '#FF0000',
+  partIndices: [0],
+  measureNumbers: [5, 6],
+});
+
+// A single note, plus its stem and beams
+const highlighted = setColor(score, {
+  color: '#0000FF',
+  targets: ['note', 'stem', 'beam'],
+  noteFilter: (n) => n._id === noteId,
+});
+
+// Strip every colour in the score
+const plain = clearColors(marked);
+```
+
+Values are the MusicXML `#RRGGBB` or `#AARRGGBB` (alpha-first) form, carried
+through verbatim.
+
+| Where | Property | MusicXML element |
+|-------|----------|------------------|
+| Note | `note.color` | `<note>` — the whole note |
+| | `note.noteTypeColor`, `note.dotColor` | `<type>`, `<dot>` |
+| | `note.notehead.color`, `note.stem.color`, `note.accidental.color` | `<notehead>`, `<stem>`, `<accidental>` |
+| | `note.beam[i].color` | `<beam>` |
+| Notations | `notation.color` | every `<notations>` child except `<tuplet>`, which has no `color` attribute in the schema |
+| Lyrics | `lyric.color`, `lyric.textColor`, `lyric.textElements[i].color` | `<lyric>`, `<text>` |
+| Directions | `directionType.color` | every `<direction-type>` child except `<image>` and `<swing>`, which have no `color` attribute |
+| Harmony | `harmony.color`, `harmony.kindColor`, `harmony.frame.color` | `<harmony>`, `<kind>`, `<frame>` |
+| Figured bass | `figuredBass.color` | `<figured-bass>` |
+| Attributes | `key.color`, `time.color`, `clef.color`, `measureStyle.color` | `<key>`, `<time>`, `<clef>`, `<measure-style>` |
+| Barlines | `barline.barStyleColor`, `barline.ending.color` | `<bar-style>`, `<ending>` |
+| Part list | `partInfo.nameColor`, `partInfo.abbreviationColor` | `<part-name>`, `<part-abbreviation>` |
+| | `partGroup.groupNameColor`, `groupAbbreviationColor`, `groupSymbolColor` | `<group-name>`, `<group-abbreviation>`, `<group-symbol>` |
+| | `displayText.color` | `<display-text>` |
+| Credits | `creditWords.color` | `<credit-words>` |
+
+`setColor` covers the note, notation, lyric, direction, harmony, figured-bass,
+attribute and barline rows; the part-list and credit colours are set by
+assigning the field. See [OPERATIONS.md](OPERATIONS.md#color-operations) for
+the full target list.
+
+Colour is presentation only — it does not affect MIDI export, playback
+timelines, or ABC serialization.
+
 ### MIDI Export
 
 ```typescript
@@ -333,6 +391,8 @@ const { valid, errors } = validate(score);
 | `addWedge(score, options)` | Add crescendo/diminuendo |
 | `addPedal(score, options)` | Add pedal marking |
 | `addGraceNote(score, options)` | Add grace note |
+| `setColor(score, options)` | Set/clear the colour of score elements |
+| `clearColors(score)` | Remove every colour in the score |
 
 See [OPERATIONS.md](OPERATIONS.md) for the complete list.
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,5 +1,6 @@
 // Core types
 export type {
+  Color,
   Score,
   ScoreMetadata,
   PartInfo,
@@ -17,12 +18,21 @@ export type {
   NoteType,
   Accidental,
   AccidentalInfo,
+  AccidentalMarkInfo,
+  NoteheadInfo,
+  StemInfo,
   TieInfo,
   BeamInfo,
   Notation,
   DirectionType,
   DynamicsValue,
   Lyric,
+  LyricTextElement,
+  HarmonyEntry,
+  HarmonyFrame,
+  FiguredBassEntry,
+  MeasureStyle,
+  DisplayText,
   TimeSignature,
   KeySignature,
   Clef,
@@ -319,6 +329,10 @@ export {
   // Caesura operations
   addCaesura,
   removeCaesura,
+  // Color operations
+  setColor,
+  clearColors,
+  ALL_COLOR_TARGETS,
 } from './operations';
 
 // Operation types
@@ -445,6 +459,9 @@ export type {
   CaesuraValue,
   AddCaesuraOptions,
   RemoveCaesuraOptions,
+  // Color operation options
+  ColorTarget,
+  SetColorOptions,
 } from './operations';
 
 // Utils (shared pitch and position utilities)

--- a/src/exporters/musicxml.ts
+++ b/src/exporters/musicxml.ts
@@ -436,6 +436,7 @@ function serializeCredit(credit: Credit, indent: string, out: string[]): void {
       if (cw.letterSpacing) attrs += ` letter-spacing="${escapeXml(cw.letterSpacing)}"`;
       if (cw.xmlLang) attrs += ` xml:lang="${escapeXml(cw.xmlLang)}"`;
       if (cw.xmlSpace) attrs += ` xml:space="${escapeXml(cw.xmlSpace)}"`;
+      if (cw.color) attrs += ` color="${escapeXml(cw.color)}"`;
       out.push(`${indent}${indent}<credit-words${attrs}>${escapeXml(cw.text)}</credit-words>`);
     }
   }
@@ -465,6 +466,7 @@ function serializeDisplayTexts(texts: DisplayText[], indent: string, out: string
     if (dt.fontStyle) attrs += ` font-style="${escapeXml(dt.fontStyle)}"`;
     if (dt.fontWeight) attrs += ` font-weight="${escapeXml(dt.fontWeight)}"`;
     if (dt.xmlSpace) attrs += ` xml:space="${escapeXml(dt.xmlSpace)}"`;
+    if (dt.color) attrs += ` color="${escapeXml(dt.color)}"`;
     out.push(`${indent}<display-text${attrs}>${escapeXml(dt.text)}</display-text>`);
   }
 }
@@ -475,6 +477,7 @@ function serializeScorePart(part: PartInfo, indent: string, out: string[]): void
   if (part.name !== undefined) {
     let pnAttrs = '';
     if (part.namePrintObject === false) pnAttrs += ' print-object="no"';
+    if (part.nameColor) pnAttrs += ` color="${escapeXml(part.nameColor)}"`;
     out.push(`${indent}  <part-name${pnAttrs}>${escapeXml(part.name)}</part-name>`);
   }
 
@@ -487,6 +490,7 @@ function serializeScorePart(part: PartInfo, indent: string, out: string[]): void
   if (part.abbreviation !== undefined) {
     let paAttrs = '';
     if (part.abbreviationPrintObject === false) paAttrs += ' print-object="no"';
+    if (part.abbreviationColor) paAttrs += ` color="${escapeXml(part.abbreviationColor)}"`;
     out.push(`${indent}  <part-abbreviation${paAttrs}>${escapeXml(part.abbreviation)}</part-abbreviation>`);
   }
 
@@ -568,7 +572,8 @@ function serializePartGroup(group: PartGroup, indent: string, out: string[]): vo
   out.push(`${indent}<part-group${attrs}>`);
 
   if (group.groupName) {
-    out.push(`${indent}  <group-name>${escapeXml(group.groupName)}</group-name>`);
+    const gnAttrs = group.groupNameColor ? ` color="${escapeXml(group.groupNameColor)}"` : '';
+    out.push(`${indent}  <group-name${gnAttrs}>${escapeXml(group.groupName)}</group-name>`);
   }
 
   if (group.groupNameDisplay && group.groupNameDisplay.length > 0) {
@@ -578,7 +583,8 @@ function serializePartGroup(group: PartGroup, indent: string, out: string[]): vo
   }
 
   if (group.groupAbbreviation) {
-    out.push(`${indent}  <group-abbreviation>${escapeXml(group.groupAbbreviation)}</group-abbreviation>`);
+    const gaAttrs = group.groupAbbreviationColor ? ` color="${escapeXml(group.groupAbbreviationColor)}"` : '';
+    out.push(`${indent}  <group-abbreviation${gaAttrs}>${escapeXml(group.groupAbbreviation)}</group-abbreviation>`);
   }
 
   if (group.groupAbbreviationDisplay && group.groupAbbreviationDisplay.length > 0) {
@@ -588,8 +594,9 @@ function serializePartGroup(group: PartGroup, indent: string, out: string[]): vo
   }
 
   if (group.groupSymbol) {
-    const defaultXAttr = group.groupSymbolDefaultX !== undefined ? ` default-x="${group.groupSymbolDefaultX}"` : '';
-    out.push(`${indent}  <group-symbol${defaultXAttr}>${group.groupSymbol}</group-symbol>`);
+    let gsAttrs = group.groupSymbolDefaultX !== undefined ? ` default-x="${group.groupSymbolDefaultX}"` : '';
+    if (group.groupSymbolColor) gsAttrs += ` color="${escapeXml(group.groupSymbolColor)}"`;
+    out.push(`${indent}  <group-symbol${gsAttrs}>${group.groupSymbol}</group-symbol>`);
   }
 
   if (group.groupBarline) {
@@ -765,6 +772,7 @@ function serializeKey(key: KeySignature, indent: string, out: string[]): void {
   if (key.number !== undefined) keyAttrs += ` number="${key.number}"`;
   if (key.printObject === false) keyAttrs += ' print-object="no"';
   else if (key.printObject === true) keyAttrs += ' print-object="yes"';
+  if (key.color) keyAttrs += ` color="${escapeXml(key.color)}"`;
   out.push(`${indent}<key${keyAttrs}>`);
 
   // Cancel (for key changes)
@@ -810,6 +818,7 @@ function serializeTime(time: TimeSignature, indent: string, out: string[]): void
   let attrs = '';
   if (time.symbol) attrs += ` symbol="${time.symbol}"`;
   if (time.printObject === false) attrs += ' print-object="no"';
+  if (time.color) attrs += ` color="${escapeXml(time.color)}"`;
   out.push(`${indent}<time${attrs}>`);
 
   // Senza misura
@@ -844,6 +853,7 @@ function serializeClef(clef: Clef, indent: string, out: string[]): void {
   if (clef.printObject === false) attrs += ' print-object="no"';
   else if (clef.printObject === true) attrs += ' print-object="yes"';
   if (clef.afterBarline) attrs += ' after-barline="yes"';
+  if (clef.color) attrs += ` color="${escapeXml(clef.color)}"`;
   out.push(`${indent}<clef${attrs}>`);
   out.push(`${indent}  <sign>${clef.sign}</sign>`);
   // Only output line if defined (percussion clefs may not have it)
@@ -916,6 +926,7 @@ function serializeNote(note: NoteEntry, indent: string, out: string[]): void {
     'print-object': note.printObject === false ? false : undefined,
     'print-dot': note.printDot !== undefined ? note.printDot : undefined,
     'print-spacing': note.printSpacing,
+    'color': note.color,
   });
   out.push(`${indent}<note${noteAttrs}>`);
 
@@ -995,14 +1006,18 @@ function serializeNote(note: NoteEntry, indent: string, out: string[]): void {
 
   // Type
   if (note.noteType) {
-    const typeAttrs = note.noteTypeSize ? ` size="${escapeXml(note.noteTypeSize)}"` : '';
+    const typeAttrs = buildAttrs({
+      'size': note.noteTypeSize,
+      'color': note.noteTypeColor,
+    });
     out.push(`${indent}  <type${typeAttrs}>${note.noteType}</type>`);
   }
 
   // Dots
   if (note.dots) {
+    const dotAttrs = note.dotColor ? ` color="${escapeXml(note.dotColor)}"` : '';
     for (let i = 0; i < note.dots; i++) {
-      out.push(`${indent}  <dot/>`);
+      out.push(`${indent}  <dot${dotAttrs}/>`);
     }
   }
 
@@ -1043,6 +1058,7 @@ function serializeNote(note: NoteEntry, indent: string, out: string[]): void {
     const stemAttrs = buildAttrs({
       'default-x': note.stem.defaultX,
       'default-y': note.stem.defaultY,
+      'color': note.stem.color,
     });
     out.push(`${indent}  <stem${stemAttrs}>${note.stem.value}</stem>`);
   }
@@ -1052,6 +1068,7 @@ function serializeNote(note: NoteEntry, indent: string, out: string[]): void {
     const nhAttrs = buildAttrs({
       'filled': note.notehead.filled,
       'parentheses': note.notehead.parentheses || undefined,
+      'color': note.notehead.color,
     });
     out.push(`${indent}  <notehead${nhAttrs}>${note.notehead.value}</notehead>`);
   }
@@ -1099,8 +1116,9 @@ function serializePitch(pitch: Pitch, indent: string, out: string[]): void {
 }
 
 function serializeBeam(beam: BeamInfo, indent: string, out: string[]): void {
-  const fanAttr = beam.fan ? ` fan="${beam.fan}"` : '';
-  out.push(`${indent}<beam number="${beam.number}"${fanAttr}>${beam.type}</beam>`);
+  let beamAttrs = beam.fan ? ` fan="${beam.fan}"` : '';
+  if (beam.color) beamAttrs += ` color="${escapeXml(beam.color)}"`;
+  out.push(`${indent}<beam number="${beam.number}"${beamAttrs}>${beam.type}</beam>`);
 }
 
 function serializeNotations(notations: Notation[], indent: string, out: string[]): void {
@@ -1185,6 +1203,7 @@ function serializeStandaloneNotation(notation: Notation, indent: string, out: st
     let attrs = ` type="${notation.tiedType}"`;
     if (notation.number !== undefined) attrs += ` number="${notation.number}"`;
     if (notation.orientation) attrs += ` orientation="${notation.orientation}"`;
+    attrs += colorAttr(notation.color);
     out.push(`${indent}  <tied${attrs}/>`);
   } else if (notation.type === 'slur') {
     let attrs = '';
@@ -1199,6 +1218,7 @@ function serializeStandaloneNotation(notation: Notation, indent: string, out: st
     if (notation.bezierX2 !== undefined) attrs += ` bezier-x2="${notation.bezierX2}"`;
     if (notation.bezierY2 !== undefined) attrs += ` bezier-y2="${notation.bezierY2}"`;
     if (notation.placement) attrs += ` placement="${notation.placement}"`;
+    attrs += colorAttr(notation.color);
     out.push(`${indent}  <slur${attrs}/>`);
   } else if (notation.type === 'tuplet') {
     let attrs = ` type="${notation.tupletType}"`;
@@ -1247,8 +1267,8 @@ function serializeStandaloneNotation(notation: Notation, indent: string, out: st
       out.push(`${indent}  <tuplet${attrs}/>`);
     }
   } else if (notation.type === 'dynamics') {
-    const placementAttr = notation.placement ? ` placement="${notation.placement}"` : '';
-    out.push(`${indent}  <dynamics${placementAttr}>`);
+    const dynAttrs = (notation.placement ? ` placement="${notation.placement}"` : '') + colorAttr(notation.color);
+    out.push(`${indent}  <dynamics${dynAttrs}>`);
     for (const dyn of notation.dynamics) {
       out.push(`${indent}    <${dyn}/>`);
     }
@@ -1262,6 +1282,7 @@ function serializeStandaloneNotation(notation: Notation, indent: string, out: st
     if (notation.placement) attrs += ` placement="${notation.placement}"`;
     if (notation.defaultX !== undefined) attrs += ` default-x="${notation.defaultX}"`;
     if (notation.defaultY !== undefined) attrs += ` default-y="${notation.defaultY}"`;
+    attrs += colorAttr(notation.color);
     if (notation.shape) {
       out.push(`${indent}  <fermata${attrs}>${notation.shape}</fermata>`);
     } else {
@@ -1273,20 +1294,24 @@ function serializeStandaloneNotation(notation: Notation, indent: string, out: st
     if (notation.number !== undefined) attrs += ` number="${notation.number}"`;
     if (notation.defaultX !== undefined) attrs += ` default-x="${notation.defaultX}"`;
     if (notation.defaultY !== undefined) attrs += ` default-y="${notation.defaultY}"`;
+    attrs += colorAttr(notation.color);
     out.push(`${indent}  <arpeggiate${attrs}/>`);
   } else if (notation.type === 'non-arpeggiate') {
     let attrs = ` type="${notation.nonArpeggiateType}"`;
     if (notation.number !== undefined) attrs += ` number="${notation.number}"`;
     if (notation.placement) attrs += ` placement="${notation.placement}"`;
+    attrs += colorAttr(notation.color);
     out.push(`${indent}  <non-arpeggiate${attrs}/>`);
   } else if (notation.type === 'accidental-mark') {
     let attrs = '';
     if (notation.placement) attrs += ` placement="${notation.placement}"`;
+    attrs += colorAttr(notation.color);
     out.push(`${indent}  <accidental-mark${attrs}>${escapeXml(notation.value)}</accidental-mark>`);
   } else if (notation.type === 'glissando') {
     let attrs = ` type="${notation.glissandoType}"`;
     if (notation.number !== undefined) attrs += ` number="${notation.number}"`;
     if (notation.lineType) attrs += ` line-type="${notation.lineType}"`;
+    attrs += colorAttr(notation.color);
     if (notation.text) {
       out.push(`${indent}  <glissando${attrs}>${escapeXml(notation.text)}</glissando>`);
     } else {
@@ -1296,6 +1321,7 @@ function serializeStandaloneNotation(notation: Notation, indent: string, out: st
     let attrs = ` type="${notation.slideType}"`;
     if (notation.number !== undefined) attrs += ` number="${notation.number}"`;
     if (notation.lineType) attrs += ` line-type="${notation.lineType}"`;
+    attrs += colorAttr(notation.color);
     if (notation.text) {
       out.push(`${indent}  <slide${attrs}>${escapeXml(notation.text)}</slide>`);
     } else {
@@ -1316,6 +1342,7 @@ function serializeArticulationsGroup(artGroup: Notation[], indent: string, out: 
       // Handle positioning attributes
       if (art.defaultX !== undefined) artAttrs += ` default-x="${art.defaultX}"`;
       if (art.defaultY !== undefined) artAttrs += ` default-y="${art.defaultY}"`;
+      artAttrs += colorAttr(art.color);
       out.push(`${indent}    <${art.articulation}${artAttrs}/>`);
     }
   }
@@ -1330,7 +1357,7 @@ function serializeOrnamentsGroup(ornaments: Notation[], indent: string, out: str
   } else {
     out.push(`${indent}  <ornaments>`);
     // Collect all accidental-marks from ornaments for serialization after ornaments
-    const allAccidentalMarks: { value: string; placement?: 'above' | 'below' }[] = [];
+    const allAccidentalMarks: { value: string; placement?: 'above' | 'below'; color?: string }[] = [];
     for (const orn of ornaments) {
       if (orn.type === 'ornament') {
         // Skip empty markers when outputting with other ornaments
@@ -1342,6 +1369,7 @@ function serializeOrnamentsGroup(ornaments: Notation[], indent: string, out: str
         if (orn.number !== undefined) wlAttrs += ` number="${orn.number}"`;
         wlAttrs += placementAttr;
         if (orn.defaultY !== undefined) wlAttrs += ` default-y="${orn.defaultY}"`;
+        wlAttrs += colorAttr(orn.color);
         out.push(`${indent}    <wavy-line${wlAttrs}/>`);
       } else if (orn.ornament === 'tremolo') {
         let tremAttrs = '';
@@ -1349,6 +1377,7 @@ function serializeOrnamentsGroup(ornaments: Notation[], indent: string, out: str
         tremAttrs += placementAttr;
         if (orn.defaultX !== undefined) tremAttrs += ` default-x="${orn.defaultX}"`;
         if (orn.defaultY !== undefined) tremAttrs += ` default-y="${orn.defaultY}"`;
+        tremAttrs += colorAttr(orn.color);
         if (orn.tremoloMarks !== undefined) {
           out.push(`${indent}    <tremolo${tremAttrs}>${orn.tremoloMarks}</tremolo>`);
         } else {
@@ -1357,6 +1386,7 @@ function serializeOrnamentsGroup(ornaments: Notation[], indent: string, out: str
       } else {
         let ornAttrs = placementAttr;
         if (orn.defaultY !== undefined) ornAttrs += ` default-y="${orn.defaultY}"`;
+        ornAttrs += colorAttr(orn.color);
         out.push(`${indent}    <${orn.ornament}${ornAttrs}/>`);
       }
       // Collect accidental marks
@@ -1367,8 +1397,8 @@ function serializeOrnamentsGroup(ornaments: Notation[], indent: string, out: str
     }
     // Serialize accidental-marks after other ornaments
     for (const am of allAccidentalMarks) {
-      const amPlacement = am.placement ? ` placement="${am.placement}"` : '';
-      out.push(`${indent}    <accidental-mark${amPlacement}>${am.value}</accidental-mark>`);
+      const amAttrs = (am.placement ? ` placement="${am.placement}"` : '') + colorAttr(am.color);
+      out.push(`${indent}    <accidental-mark${amAttrs}>${am.value}</accidental-mark>`);
     }
     out.push(`${indent}  </ornaments>`);
   }
@@ -1383,6 +1413,7 @@ function serializeTechnicalGroup(technicals: Notation[], indent: string, out: st
       if (techNotation.defaultX !== undefined) placementAttr += ` default-x="${techNotation.defaultX}"`;
       if (techNotation.defaultY !== undefined) placementAttr += ` default-y="${techNotation.defaultY}"`;
       if (techNotation.fontSize !== undefined) placementAttr += ` font-size="${techNotation.fontSize}"`;
+      placementAttr += colorAttr(techNotation.color);
       if (tech.technical === 'bend' && (techNotation.bendAlter !== undefined || techNotation.preBend || techNotation.release)) {
         out.push(`${indent}    <bend${placementAttr}>`);
         if (techNotation.bendAlter !== undefined) {
@@ -1459,6 +1490,7 @@ function serializeLyric(lyric: Lyric, indent: string, out: string[]): void {
   if (lyric.relativeX !== undefined) attrs += ` relative-x="${lyric.relativeX}"`;
   if (lyric.justify) attrs += ` justify="${escapeXml(lyric.justify)}"`;
   if (lyric.placement) attrs += ` placement="${lyric.placement}"`;
+  attrs += colorAttr(lyric.color);
   out.push(`${indent}<lyric${attrs}>`);
 
   // Multiple text elements with elision
@@ -1468,7 +1500,7 @@ function serializeLyric(lyric: Lyric, indent: string, out: string[]): void {
       if (te.syllabic) {
         out.push(`${indent}  <syllabic>${te.syllabic}</syllabic>`);
       }
-      out.push(`${indent}  <text>${escapeXml(te.text)}</text>`);
+      out.push(`${indent}  <text${colorAttr(te.color)}>${escapeXml(te.text)}</text>`);
       // Add elision between text elements (but not after the last one)
       if (i < lyric.textElements.length - 1) {
         out.push(`${indent}  <elision/>`);
@@ -1479,12 +1511,14 @@ function serializeLyric(lyric: Lyric, indent: string, out: string[]): void {
     if (lyric.syllabic) {
       out.push(`${indent}  <syllabic>${lyric.syllabic}</syllabic>`);
     }
-    out.push(`${indent}  <text>${escapeXml(lyric.text)}</text>`);
+    const textColor = lyric.textColor ?? lyric.textElements?.[0]?.color;
+    out.push(`${indent}  <text${colorAttr(textColor)}>${escapeXml(lyric.text)}</text>`);
   }
 
   if (lyric.extend) {
-    if (typeof lyric.extend === 'object' && lyric.extend.type) {
-      out.push(`${indent}  <extend type="${lyric.extend.type}"/>`);
+    if (typeof lyric.extend === 'object') {
+      const extendAttrs = (lyric.extend.type ? ` type="${lyric.extend.type}"` : '') + colorAttr(lyric.extend.color);
+      out.push(`${indent}  <extend${extendAttrs}/>`);
     } else {
       out.push(`${indent}  <extend/>`);
     }
@@ -1599,6 +1633,7 @@ function serializeDirectionType(dirType: DirectionType, indent: string, out: str
       if (dirType.defaultY !== undefined) dynAttrs += ` default-y="${dirType.defaultY}"`;
       if (dirType.relativeX !== undefined) dynAttrs += ` relative-x="${dirType.relativeX}"`;
       if (dirType.halign) dynAttrs += ` halign="${dirType.halign}"`;
+      dynAttrs += colorAttr(dirType.color);
       out.push(`${indent}  <dynamics${dynAttrs}>`);
       if (dirType.value) {
         out.push(`${indent}    <${dirType.value}/>`);
@@ -1615,6 +1650,7 @@ function serializeDirectionType(dirType: DirectionType, indent: string, out: str
       if (dirType.spread !== undefined) wedgeAttrs += ` spread="${dirType.spread}"`;
       if (dirType.defaultY !== undefined) wedgeAttrs += ` default-y="${dirType.defaultY}"`;
       if (dirType.relativeX !== undefined) wedgeAttrs += ` relative-x="${dirType.relativeX}"`;
+      wedgeAttrs += colorAttr(dirType.color);
       out.push(`${indent}  <wedge${wedgeAttrs}/>`);
       break;
     }
@@ -1626,6 +1662,7 @@ function serializeDirectionType(dirType: DirectionType, indent: string, out: str
       if (dirType.defaultY !== undefined) metAttrs += ` default-y="${dirType.defaultY}"`;
       if (dirType.fontFamily) metAttrs += ` font-family="${escapeXml(dirType.fontFamily)}"`;
       if (dirType.fontSize) metAttrs += ` font-size="${escapeXml(dirType.fontSize)}"`;
+      metAttrs += colorAttr(dirType.color);
       out.push(`${indent}  <metronome${metAttrs}>`);
       out.push(`${indent}    <beat-unit>${dirType.beatUnit}</beat-unit>`);
       if (dirType.beatUnitDot) {
@@ -1670,6 +1707,7 @@ function serializeDirectionType(dirType: DirectionType, indent: string, out: str
       if (dirType.defaultY !== undefined) rehAttrs += ` default-y="${dirType.defaultY}"`;
       if (dirType.fontSize) rehAttrs += ` font-size="${escapeXml(dirType.fontSize)}"`;
       if (dirType.fontWeight) rehAttrs += ` font-weight="${escapeXml(dirType.fontWeight)}"`;
+      rehAttrs += colorAttr(dirType.color);
       out.push(`${indent}  <rehearsal${rehAttrs}>${escapeXml(dirType.text)}</rehearsal>`);
       break;
     }
@@ -1681,6 +1719,7 @@ function serializeDirectionType(dirType: DirectionType, indent: string, out: str
       if (dirType.lineType) bracketAttrs += ` line-type="${dirType.lineType}"`;
       if (dirType.defaultY !== undefined) bracketAttrs += ` default-y="${dirType.defaultY}"`;
       if (dirType.relativeX !== undefined) bracketAttrs += ` relative-x="${dirType.relativeX}"`;
+      bracketAttrs += colorAttr(dirType.color);
       out.push(`${indent}  <bracket${bracketAttrs}/>`);
       break;
     }
@@ -1691,12 +1730,13 @@ function serializeDirectionType(dirType: DirectionType, indent: string, out: str
       if (dirType.dashLength !== undefined) dashAttrs += ` dash-length="${dirType.dashLength}"`;
       if (dirType.defaultY !== undefined) dashAttrs += ` default-y="${dirType.defaultY}"`;
       if (dirType.spaceLength !== undefined) dashAttrs += ` space-length="${dirType.spaceLength}"`;
+      dashAttrs += colorAttr(dirType.color);
       out.push(`${indent}  <dashes${dashAttrs}/>`);
       break;
     }
 
     case 'accordion-registration':
-      out.push(`${indent}  <accordion-registration>`);
+      out.push(`${indent}  <accordion-registration${colorAttr(dirType.color)}>`);
       if (dirType.high) {
         out.push(`${indent}    <accordion-high/>`);
       }
@@ -1720,33 +1760,34 @@ function serializeDirectionType(dirType: DirectionType, indent: string, out: str
       if (dirType.defaultY !== undefined) otherAttrs += ` default-y="${dirType.defaultY}"`;
       if (dirType.halign) otherAttrs += ` halign="${escapeXml(dirType.halign)}"`;
       if (dirType.printObject === false) otherAttrs += ' print-object="no"';
+      otherAttrs += colorAttr(dirType.color);
       out.push(`${indent}  <other-direction${otherAttrs}>${escapeXml(dirType.text)}</other-direction>`);
     }
       break;
 
     case 'segno':
-      out.push(`${indent}  <segno/>`);
+      out.push(`${indent}  <segno${colorAttr(dirType.color)}/>`);
       break;
 
     case 'coda':
-      out.push(`${indent}  <coda/>`);
+      out.push(`${indent}  <coda${colorAttr(dirType.color)}/>`);
       break;
 
     case 'eyeglasses':
-      out.push(`${indent}  <eyeglasses/>`);
+      out.push(`${indent}  <eyeglasses${colorAttr(dirType.color)}/>`);
       break;
 
     case 'damp':
-      out.push(`${indent}  <damp/>`);
+      out.push(`${indent}  <damp${colorAttr(dirType.color)}/>`);
       break;
 
     case 'damp-all':
-      out.push(`${indent}  <damp-all/>`);
+      out.push(`${indent}  <damp-all${colorAttr(dirType.color)}/>`);
       break;
 
     case 'scordatura':
       if (dirType.accords && dirType.accords.length > 0) {
-        out.push(`${indent}  <scordatura>`);
+        out.push(`${indent}  <scordatura${colorAttr(dirType.color)}>`);
         for (const accord of dirType.accords) {
           out.push(`${indent}    <accord string="${accord.string}">`);
           out.push(`${indent}      <tuning-step>${accord.tuningStep}</tuning-step>`);
@@ -1758,13 +1799,13 @@ function serializeDirectionType(dirType: DirectionType, indent: string, out: str
         }
         out.push(`${indent}  </scordatura>`);
       } else {
-        out.push(`${indent}  <scordatura/>`);
+        out.push(`${indent}  <scordatura${colorAttr(dirType.color)}/>`);
       }
       break;
 
     case 'harp-pedals':
       if (dirType.pedalTunings && dirType.pedalTunings.length > 0) {
-        out.push(`${indent}  <harp-pedals>`);
+        out.push(`${indent}  <harp-pedals${colorAttr(dirType.color)}>`);
         for (const pt of dirType.pedalTunings) {
           out.push(`${indent}    <pedal-tuning>`);
           out.push(`${indent}      <pedal-step>${pt.pedalStep}</pedal-step>`);
@@ -1773,7 +1814,7 @@ function serializeDirectionType(dirType: DirectionType, indent: string, out: str
         }
         out.push(`${indent}  </harp-pedals>`);
       } else {
-        out.push(`${indent}  <harp-pedals/>`);
+        out.push(`${indent}  <harp-pedals${colorAttr(dirType.color)}/>`);
       }
       break;
 
@@ -1790,13 +1831,14 @@ function serializeDirectionType(dirType: DirectionType, indent: string, out: str
       if (dirType.defaultY !== undefined) pedalAttrs += ` default-y="${dirType.defaultY}"`;
       if (dirType.relativeX !== undefined) pedalAttrs += ` relative-x="${dirType.relativeX}"`;
       if (dirType.halign) pedalAttrs += ` halign="${dirType.halign}"`;
+      pedalAttrs += colorAttr(dirType.color);
       out.push(`${indent}  <pedal${pedalAttrs}/>`);
       break;
     }
 
     case 'octave-shift': {
       const sizeAttr = dirType.size !== undefined ? ` size="${dirType.size}"` : '';
-      out.push(`${indent}  <octave-shift type="${dirType.type}"${sizeAttr}/>`);
+      out.push(`${indent}  <octave-shift type="${dirType.type}"${sizeAttr}${colorAttr(dirType.color)}/>`);
       break;
     }
 
@@ -1828,13 +1870,14 @@ function serializeBarline(barline: Barline, indent: string, out: string[]): void
   out.push(`${indent}<barline${attrs}>`);
 
   if (barline.barStyle) {
-    out.push(`${indent}  <bar-style>${barline.barStyle}</bar-style>`);
+    out.push(`${indent}  <bar-style${colorAttr(barline.barStyleColor)}>${barline.barStyle}</bar-style>`);
   }
 
   if (barline.ending) {
     let endingAttrs = ` number="${barline.ending.number}" type="${barline.ending.type}"`;
     if (barline.ending.defaultY !== undefined) endingAttrs += ` default-y="${barline.ending.defaultY}"`;
     if (barline.ending.endLength !== undefined) endingAttrs += ` end-length="${barline.ending.endLength}"`;
+    endingAttrs += colorAttr(barline.ending.color);
     if (barline.ending.text) {
       out.push(`${indent}  <ending${endingAttrs}>${escapeXml(barline.ending.text)}</ending>`);
     } else {
@@ -1869,6 +1912,13 @@ function escapeXml(str: string): string {
   // Fast path: most attribute/text values contain no special chars.
   if (!XML_ESCAPE_TEST.test(str)) return str;
   return str.replace(XML_ESCAPE_RE, (ch) => XML_ESCAPE_MAP[ch]);
+}
+
+/**
+ * Render the MusicXML `color` attribute, or nothing when unset.
+ */
+function colorAttr(color: string | undefined): string {
+  return color ? ` color="${escapeXml(color)}"` : '';
 }
 
 /**
@@ -1941,7 +1991,7 @@ function serializeStaffDetails(sd: StaffDetails, indent: string, out: string[]):
 }
 
 function serializeMeasureStyle(ms: MeasureStyle, indent: string, out: string[]): void {
-  out.push(`${indent}<measure-style${buildAttrs({ number: ms.number })}>`);
+  out.push(`${indent}<measure-style${buildAttrs({ number: ms.number, color: ms.color })}>`);
 
   pushOptionalElement(out, `${indent}  `, 'multiple-rest', ms.multipleRest);
 
@@ -1978,6 +2028,7 @@ function serializeHarmony(harmony: HarmonyEntry, indent: string, out: string[]):
     'default-y': harmony.defaultY,
     halign: harmony.halign,
     'font-size': harmony.fontSize,
+    color: harmony.color,
   });
   out.push(`${indent}<harmony${attrs}>`);
 
@@ -1993,6 +2044,7 @@ function serializeHarmony(harmony: HarmonyEntry, indent: string, out: string[]):
   let kindAttrs = '';
   if (harmony.kindText !== undefined) kindAttrs += ` text="${escapeXml(harmony.kindText)}"`;
   if (harmony.kindHalign) kindAttrs += ` halign="${escapeXml(harmony.kindHalign)}"`;
+  kindAttrs += colorAttr(harmony.kindColor);
   out.push(`${indent}  <kind${kindAttrs}>${escapeXml(harmony.kind)}</kind>`);
 
   // Bass
@@ -2027,7 +2079,7 @@ function serializeHarmony(harmony: HarmonyEntry, indent: string, out: string[]):
 
   // Frame
   if (harmony.frame) {
-    out.push(`${indent}  <frame>`);
+    out.push(`${indent}  <frame${colorAttr(harmony.frame.color)}>`);
     if (harmony.frame.frameStrings !== undefined) {
       out.push(`${indent}    <frame-strings>${harmony.frame.frameStrings}</frame-strings>`);
     }
@@ -2074,6 +2126,7 @@ function serializeFiguredBass(fb: FiguredBassEntry, indent: string, out: string[
   let attrs = '';
   if (fb._id) attrs += ` id="${escapeXml(fb._id)}"`;
   if (fb.parentheses) attrs += ' parentheses="yes"';
+  attrs += colorAttr(fb.color);
   out.push(`${indent}<figured-bass${attrs}>`);
 
   for (const fig of fb.figures) {
@@ -2088,8 +2141,9 @@ function serializeFiguredBass(fb: FiguredBassEntry, indent: string, out: string[
       out.push(`${indent}    <suffix>${escapeXml(fig.suffix)}</suffix>`);
     }
     if (fig.extend) {
-      if (typeof fig.extend === 'object' && fig.extend.type) {
-        out.push(`${indent}    <extend type="${fig.extend.type}"/>`);
+      if (typeof fig.extend === 'object') {
+        const extendAttrs = (fig.extend.type ? ` type="${fig.extend.type}"` : '') + colorAttr(fig.extend.color);
+        out.push(`${indent}    <extend${extendAttrs}/>`);
       } else {
         out.push(`${indent}    <extend/>`);
       }

--- a/src/importers/musicxml.ts
+++ b/src/importers/musicxml.ts
@@ -805,6 +805,7 @@ function parseCredits(elements: XmlChild[]): Credit[] | undefined {
       if (a['letter-spacing']) cw.letterSpacing = a['letter-spacing'];
       if (a['xml:lang']) cw.xmlLang = a['xml:lang'];
       if (a['xml:space']) cw.xmlSpace = a['xml:space'];
+      if (a['color']) cw.color = a['color'];
       return cw;
     });
     const images = collectElements(content, 'credit-image', (_c, a) => {
@@ -835,6 +836,7 @@ function parseDisplayTexts(elements: XmlChild[]): DisplayText[] {
     if (a['font-style']) dt.fontStyle = a['font-style'];
     if (a['font-weight']) dt.fontWeight = a['font-weight'];
     if (a['xml:space']) dt.xmlSpace = a['xml:space'];
+    if (a['color']) dt.color = a['color'];
     return dt;
   });
 }
@@ -863,6 +865,7 @@ function parsePartList(elements: XmlChild[]): PartListEntry[] {
           if (pnAttrs['print-object'] === 'no') {
             partInfo.namePrintObject = false;
           }
+          if (pnAttrs['color']) partInfo.nameColor = pnAttrs['color'];
           break;
         }
       }
@@ -885,6 +888,7 @@ function parsePartList(elements: XmlChild[]): PartListEntry[] {
           if (paAttrs['print-object'] === 'no') {
             partInfo.abbreviationPrintObject = false;
           }
+          if (paAttrs['color']) partInfo.abbreviationColor = paAttrs['color'];
           break;
         }
       }
@@ -972,13 +976,19 @@ function parsePartList(elements: XmlChild[]): PartListEntry[] {
       };
       if (attrs['number']) group.number = parseInt(attrs['number'], 10);
 
-      const name = getElementText(content, 'group-name');
-      if (name) group.groupName = name;
+      parseFirstElement(content, 'group-name', (c, a) => {
+        const name = extractText(c);
+        if (name) group.groupName = name;
+        if (a['color']) group.groupNameColor = a['color'];
+      });
       const gnd = parseFirstElement(content, 'group-name-display', (c) => parseDisplayTexts(c));
       if (gnd) group.groupNameDisplay = gnd;
 
-      const abbr = getElementText(content, 'group-abbreviation');
-      if (abbr) group.groupAbbreviation = abbr;
+      parseFirstElement(content, 'group-abbreviation', (c, a) => {
+        const abbr = extractText(c);
+        if (abbr) group.groupAbbreviation = abbr;
+        if (a['color']) group.groupAbbreviationColor = a['color'];
+      });
       const gad = parseFirstElement(content, 'group-abbreviation-display', (c) => parseDisplayTexts(c));
       if (gad) group.groupAbbreviationDisplay = gad;
 
@@ -989,6 +999,7 @@ function parsePartList(elements: XmlChild[]): PartListEntry[] {
           group.groupSymbol = symbol as PartGroup['groupSymbol'];
         }
         if (a['default-x']) group.groupSymbolDefaultX = parseFloat(a['default-x']);
+        if (a['color']) group.groupSymbolColor = a['color'];
       });
 
       const barline = getElementText(content, 'group-barline');
@@ -1184,6 +1195,7 @@ function parseAttributes(
       if (keyAttrs['number']) key.number = parseInt(keyAttrs['number'], 10);
       if (keyAttrs['print-object'] === 'no') key.printObject = false;
       else if (keyAttrs['print-object'] === 'yes') key.printObject = true;
+      if (keyAttrs['color']) key.color = keyAttrs['color'];
       keys.push(key);
     }
   }
@@ -1279,6 +1291,7 @@ function parseTimeSignature(elements: XmlChild[], parentElements: XmlChild[]): T
       if (attrs['print-object'] === 'no') {
         time.printObject = false;
       }
+      if (attrs['color']) time.color = attrs['color'];
       break;
     }
   }
@@ -1350,6 +1363,9 @@ function parseClef(elements: XmlChild[], attrs: Record<string, string>): Clef {
   if (attrs['after-barline'] === 'yes') {
     clef.afterBarline = true;
   }
+  if (attrs['color']) {
+    clef.color = attrs['color'];
+  }
 
   return clef;
 }
@@ -1386,6 +1402,7 @@ function parseNote(elements: XmlChild[], attrs: Record<string, string>): NoteEnt
   if (attrs['print-dot'] === 'yes') note.printDot = true;
   if (attrs['print-spacing'] === 'yes') note.printSpacing = true;
   if (attrs['print-spacing'] === 'no') note.printSpacing = false;
+  if (attrs['color']) note.color = attrs['color'];
 
   // Single pass over all child elements
   let dotCount = 0;
@@ -1422,6 +1439,7 @@ function parseNote(elements: XmlChild[], attrs: Record<string, string>): NoteEnt
         break;
       case 'dot':
         dotCount++;
+        if (elAttrs['color'] && note.dotColor === undefined) note.dotColor = elAttrs['color'];
         break;
       case 'instrument':
         if (elAttrs['id']) note.instrument = elAttrs['id'];
@@ -1456,6 +1474,7 @@ function parseNote(elements: XmlChild[], attrs: Record<string, string>): NoteEnt
         const noteType = extractText(c);
         if (isValidNoteType(noteType)) note.noteType = noteType;
         if (elAttrs['size']) note.noteTypeSize = elAttrs['size'];
+        if (elAttrs['color']) note.noteTypeColor = elAttrs['color'];
         break;
       }
       case 'accidental': {
@@ -1481,6 +1500,7 @@ function parseNote(elements: XmlChild[], attrs: Record<string, string>): NoteEnt
           note.stem = { value: stemValue };
           if (elAttrs['default-x']) note.stem.defaultX = parseFloat(elAttrs['default-x']);
           if (elAttrs['default-y']) note.stem.defaultY = parseFloat(elAttrs['default-y']);
+          if (elAttrs['color']) note.stem.color = elAttrs['color'];
         }
         break;
       }
@@ -1491,6 +1511,7 @@ function parseNote(elements: XmlChild[], attrs: Record<string, string>): NoteEnt
           if (elAttrs['filled'] === 'yes') nhInfo.filled = true;
           else if (elAttrs['filled'] === 'no') nhInfo.filled = false;
           if (elAttrs['parentheses'] === 'yes') nhInfo.parentheses = true;
+          if (elAttrs['color']) nhInfo.color = elAttrs['color'];
           note.notehead = nhInfo;
         }
         break;
@@ -1597,6 +1618,7 @@ function parseBeam(elements: XmlChild[], attrs: Record<string, string>): BeamInf
   if (attrs['fan'] && validFans.includes(attrs['fan'])) {
     beam.fan = attrs['fan'] as BeamInfo['fan'];
   }
+  if (attrs['color']) beam.color = attrs['color'];
   return beam;
 }
 
@@ -1613,6 +1635,7 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
         tiedType: (attrs['type'] as 'start' | 'stop' | 'continue' | 'let-ring') || 'start',
         number: attrs['number'] ? parseInt(attrs['number'], 10) : undefined,
         orientation: attrs['orientation'] as 'over' | 'under' | undefined,
+        color: attrs['color'],
         notationsIndex,
       };
       notations.push(tied);
@@ -1631,6 +1654,7 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
         bezierX2: attrs['bezier-x2'] ? parseFloat(attrs['bezier-x2']) : undefined,
         bezierY2: attrs['bezier-y2'] ? parseFloat(attrs['bezier-y2']) : undefined,
         placement: attrs['placement'] as 'above' | 'below' | undefined,
+        color: attrs['color'],
         notationsIndex,
       };
       notations.push(slur);
@@ -1717,6 +1741,7 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
             if (artAttrs['default-y']) {
               artNotation.defaultY = parseFloat(artAttrs['default-y']);
             }
+            if (artAttrs['color']) artNotation.color = artAttrs['color'];
             notations.push(artNotation);
           }
         }
@@ -1732,7 +1757,13 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
       // Collect accidental-marks for the ornaments group
       const accidentalMarks = collectElements(ornContent, 'accidental-mark', (c, a) => {
         const value = extractText(c);
-        return isValidAccidental(value) ? { value: value as Accidental, placement: a['placement'] as 'above' | 'below' | undefined } : null;
+        return isValidAccidental(value)
+          ? {
+            value: value as Accidental,
+            placement: a['placement'] as 'above' | 'below' | undefined,
+            color: a['color'],
+          }
+          : null;
       }).filter((m) => m !== null);
 
       for (const orn of ornContent) {
@@ -1751,6 +1782,7 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
             if (ornAttrs['default-y']) {
               ornNotation.defaultY = parseFloat(ornAttrs['default-y']);
             }
+            if (ornAttrs['color']) ornNotation.color = ornAttrs['color'];
             // Attach accidental marks to the first ornament in the group
             if (accidentalMarks.length > 0 && notations.filter(n => n.type === 'ornament').length === 0) {
               ornNotation.accidentalMarks = accidentalMarks as any;
@@ -1772,6 +1804,7 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
           if (wlAttrs['default-y']) {
             wlNotation.defaultY = parseFloat(wlAttrs['default-y']);
           }
+          if (wlAttrs['color']) wlNotation.color = wlAttrs['color'];
           notations.push(wlNotation);
         }
         // Tremolo
@@ -1788,6 +1821,7 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
           };
           if (tremAttrs['default-x']) tremNotation.defaultX = parseFloat(tremAttrs['default-x']);
           if (tremAttrs['default-y']) tremNotation.defaultY = parseFloat(tremAttrs['default-y']);
+          if (tremAttrs['color']) tremNotation.color = tremAttrs['color'];
           notations.push(tremNotation);
         }
       }
@@ -1830,6 +1864,7 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
           if (hasElement(bendContent, 'pre-bend')) techNotation.preBend = true;
           if (hasElement(bendContent, 'release')) techNotation.release = true;
           if (hasElement(bendContent, 'with-bar')) techNotation.withBar = true;
+          if (techAttrs['color']) techNotation.color = techAttrs['color'];
           notations.push(techNotation);
         }
         // Handle other technical elements
@@ -1892,6 +1927,9 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
             if (techAttrs['font-size']) {
               notation.fontSize = techAttrs['font-size'];
             }
+            if (techAttrs['color']) {
+              notation.color = techAttrs['color'];
+            }
             notations.push(notation);
           }
         }
@@ -1924,6 +1962,7 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
           notationsIndex,
         };
         if (otherDynamics) dynNotation.otherDynamics = otherDynamics;
+        if (dynAttrs['color']) dynNotation.color = dynAttrs['color'];
         notations.push(dynNotation);
       }
     } else if (el.tagName === 'fermata') {
@@ -1934,6 +1973,7 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
         shape: shape as any || undefined,
         fermataType: a['type'] as 'upright' | 'inverted' | undefined,
         placement: a['placement'] as 'above' | 'below' | undefined,
+        color: a['color'],
         notationsIndex,
       };
       if (a['default-x']) (fermataNotation as any).defaultX = parseFloat(a['default-x']);
@@ -1949,6 +1989,7 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
       };
       if (arpAttrs['default-x']) arpNotation.defaultX = parseFloat(arpAttrs['default-x']);
       if (arpAttrs['default-y']) arpNotation.defaultY = parseFloat(arpAttrs['default-y']);
+      if (arpAttrs['color']) arpNotation.color = arpAttrs['color'];
       notations.push(arpNotation);
     } else if (el.tagName === 'non-arpeggiate') {
       const nonArpAttrs = el.attributes as Record<string, string>;
@@ -1957,6 +1998,7 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
         nonArpeggiateType: nonArpAttrs['type'] as 'top' | 'bottom',
         number: nonArpAttrs['number'] ? parseInt(nonArpAttrs['number'], 10) : undefined,
         placement: nonArpAttrs['placement'] as 'above' | 'below' | undefined,
+        color: nonArpAttrs['color'],
         notationsIndex,
       });
     } else if (el.tagName === 'accidental-mark') {
@@ -1967,6 +2009,7 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
         type: 'accidental-mark',
         value,
         placement: amAttrs['placement'] as 'above' | 'below' | undefined,
+        color: amAttrs['color'],
         notationsIndex,
       });
     } else if (el.tagName === 'glissando') {
@@ -1985,6 +2028,7 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
         number: glissAttrs['number'] ? parseInt(glissAttrs['number'], 10) : undefined,
         lineType: glissAttrs['line-type'] as 'solid' | 'dashed' | 'dotted' | 'wavy' | undefined,
         text,
+        color: glissAttrs['color'],
         notationsIndex,
       });
     } else if (el.tagName === 'slide') {
@@ -1996,6 +2040,7 @@ function parseNotations(elements: XmlChild[], notationsIndex: number = 0): Notat
         slideType: slideAttrs['type'] === 'stop' ? 'stop' : 'start',
         number: slideAttrs['number'] ? parseInt(slideAttrs['number'], 10) : undefined,
         lineType: slideAttrs['line-type'] as 'solid' | 'dashed' | 'dotted' | 'wavy' | undefined,
+        color: slideAttrs['color'],
         notationsIndex,
       };
       if (slideText) slideNotation.text = slideText;
@@ -2027,12 +2072,14 @@ function parseLyric(elements: XmlChild[], attrs: Record<string, string>): Lyric 
       }
     } else if (el.tagName === 'text') {
       const content = el.children;
+      const textColor = (el.attributes as Record<string, string>)['color'];
       let foundText = false;
       for (const item of content) {
         if (typeof item === 'string') {
           textElements.push({
             text: item,
             syllabic: currentSyllabic,
+            color: textColor,
           });
           currentSyllabic = undefined;
           foundText = true;
@@ -2044,6 +2091,7 @@ function parseLyric(elements: XmlChild[], attrs: Record<string, string>): Lyric 
         textElements.push({
           text: '',
           syllabic: currentSyllabic,
+          color: textColor,
         });
         currentSyllabic = undefined;
       }
@@ -2080,9 +2128,18 @@ function parseLyric(elements: XmlChild[], attrs: Record<string, string>): Lyric 
     lyric.placement = attrs['placement'] as 'above' | 'below';
   }
 
+  if (attrs['color']) {
+    lyric.color = attrs['color'];
+  }
+
   // Set syllabic from first text element
   if (textElements.length > 0 && textElements[0].syllabic) {
     lyric.syllabic = textElements[0].syllabic;
+  }
+
+  // Colour of the first <text>; per-element colours live on textElements
+  if (textElements.length > 0 && textElements[0].color) {
+    lyric.textColor = textElements[0].color;
   }
 
   // If multiple text elements (elision case), store all of them
@@ -2099,8 +2156,9 @@ function parseLyric(elements: XmlChild[], attrs: Record<string, string>): Lyric 
     if (el.tagName === 'extend') {
       const extendAttrs = el.attributes as Record<string, string>;
       const extendType = extendAttrs['type'] as 'start' | 'stop' | 'continue' | undefined;
-      if (extendType) {
-        lyric.extend = { type: extendType };
+      const extendColor = extendAttrs['color'];
+      if (extendType || extendColor) {
+        lyric.extend = { type: extendType, color: extendColor };
       } else {
         lyric.extend = true;
       }
@@ -2251,6 +2309,7 @@ function parseDirectionTypes(elements: XmlChild[]): DirectionType[] {
             if (dynAttrs['default-y']) result.defaultY = parseFloat(dynAttrs['default-y']);
             if (dynAttrs['relative-x']) result.relativeX = parseFloat(dynAttrs['relative-x']);
             if (dynAttrs['halign']) result.halign = dynAttrs['halign'];
+            if (dynAttrs['color']) result.color = dynAttrs['color'];
             results.push(result);
             foundStandard = true;
             break; // Only one dynamics value per dynamics element
@@ -2265,6 +2324,7 @@ function parseDirectionTypes(elements: XmlChild[]): DirectionType[] {
             if (dynAttrs['default-y']) result.defaultY = parseFloat(dynAttrs['default-y']);
             if (dynAttrs['relative-x']) result.relativeX = parseFloat(dynAttrs['relative-x']);
             if (dynAttrs['halign']) result.halign = dynAttrs['halign'];
+            if (dynAttrs['color']) result.color = dynAttrs['color'];
             results.push(result);
           }
         }
@@ -2281,6 +2341,7 @@ function parseDirectionTypes(elements: XmlChild[]): DirectionType[] {
         if (wedgeAttrs['spread']) result.spread = parseFloat(wedgeAttrs['spread']);
         if (wedgeAttrs['default-y']) result.defaultY = parseFloat(wedgeAttrs['default-y']);
         if (wedgeAttrs['relative-x']) result.relativeX = parseFloat(wedgeAttrs['relative-x']);
+        if (wedgeAttrs['color']) result.color = wedgeAttrs['color'];
         results.push(result);
       }
       continue;
@@ -2331,6 +2392,7 @@ function parseDirectionTypes(elements: XmlChild[]): DirectionType[] {
         if (metAttrs['default-y']) result.defaultY = parseFloat(metAttrs['default-y']);
         if (metAttrs['font-family']) result.fontFamily = metAttrs['font-family'];
         if (metAttrs['font-size']) result.fontSize = metAttrs['font-size'];
+        if (metAttrs['color']) result.color = metAttrs['color'];
         results.push(result);
       }
       continue;
@@ -2370,6 +2432,7 @@ function parseDirectionTypes(elements: XmlChild[]): DirectionType[] {
         if (a['default-y']) result.defaultY = parseFloat(a['default-y']);
         if (a['font-size']) result.fontSize = a['font-size'];
         if (a['font-weight']) result.fontWeight = a['font-weight'];
+        if (a['color']) result.color = a['color'];
         results.push(result);
       }
       continue;
@@ -2386,6 +2449,7 @@ function parseDirectionTypes(elements: XmlChild[]): DirectionType[] {
         if (bracketAttrs['line-type']) result.lineType = bracketAttrs['line-type'] as 'solid' | 'dashed' | 'dotted' | 'wavy';
         if (bracketAttrs['default-y']) result.defaultY = parseFloat(bracketAttrs['default-y']);
         if (bracketAttrs['relative-x']) result.relativeX = parseFloat(bracketAttrs['relative-x']);
+        if (bracketAttrs['color']) result.color = bracketAttrs['color'];
         results.push(result);
       }
       continue;
@@ -2401,6 +2465,7 @@ function parseDirectionTypes(elements: XmlChild[]): DirectionType[] {
         if (dashAttrs['dash-length']) result.dashLength = parseFloat(dashAttrs['dash-length']);
         if (dashAttrs['default-y']) result.defaultY = parseFloat(dashAttrs['default-y']);
         if (dashAttrs['space-length']) result.spaceLength = parseFloat(dashAttrs['space-length']);
+        if (dashAttrs['color']) result.color = dashAttrs['color'];
         results.push(result);
       }
       continue;
@@ -2409,7 +2474,9 @@ function parseDirectionTypes(elements: XmlChild[]): DirectionType[] {
     // Accordion registration
     if (el.tagName === 'accordion-registration') {
       const accContent = el.children;
+      const accRegAttrs = el.attributes as Record<string, string>;
       const result: DirectionType = { kind: 'accordion-registration' };
+      if (accRegAttrs['color']) result.color = accRegAttrs['color'];
       for (const acc of accContent) {
         if (typeof acc === 'string') continue;
         if (acc.tagName === 'accordion-high') {
@@ -2446,6 +2513,7 @@ function parseDirectionTypes(elements: XmlChild[]): DirectionType[] {
           if (otherAttrs['default-y']) result.defaultY = parseFloat(otherAttrs['default-y']);
           if (otherAttrs['halign']) result.halign = otherAttrs['halign'];
           if (otherAttrs['print-object'] === 'no') result.printObject = false;
+          if (otherAttrs['color']) result.color = otherAttrs['color'];
           results.push(result);
           break;
         }
@@ -2453,39 +2521,23 @@ function parseDirectionTypes(elements: XmlChild[]): DirectionType[] {
       continue;
     }
 
-    // Segno
-    if (el.tagName === 'segno') {
-      results.push({ kind: 'segno' });
-      continue;
-    }
-
-    // Coda
-    if (el.tagName === 'coda') {
-      results.push({ kind: 'coda' });
-      continue;
-    }
-
-    // Eyeglasses
-    if (el.tagName === 'eyeglasses') {
-      results.push({ kind: 'eyeglasses' });
-      continue;
-    }
-
-    // Damp
-    if (el.tagName === 'damp') {
-      results.push({ kind: 'damp' });
-      continue;
-    }
-
-    // Damp-all
-    if (el.tagName === 'damp-all') {
-      results.push({ kind: 'damp-all' });
+    // Segno / Coda / Eyeglasses / Damp / Damp-all — marker elements whose only
+    // modelled styling is the color attribute.
+    if (
+      el.tagName === 'segno' || el.tagName === 'coda' || el.tagName === 'eyeglasses' ||
+      el.tagName === 'damp' || el.tagName === 'damp-all'
+    ) {
+      const markerColor = (el.attributes as Record<string, string>)['color'];
+      const result = { kind: el.tagName } as DirectionType;
+      if (markerColor) (result as { color?: string }).color = markerColor;
+      results.push(result);
       continue;
     }
 
     // Scordatura
     if (el.tagName === 'scordatura') {
       const scordContent = el.children;
+      const scordColor = (el.attributes as Record<string, string>)['color'];
       const accords: { string: number; tuningStep: string; tuningAlter?: number; tuningOctave: number }[] = [];
       for (const sc of scordContent) {
         if (typeof sc === 'string') continue;
@@ -2506,13 +2558,14 @@ function parseDirectionTypes(elements: XmlChild[]): DirectionType[] {
           }
         }
       }
-      results.push({ kind: 'scordatura', accords: accords.length > 0 ? accords : undefined });
+      results.push({ kind: 'scordatura', accords: accords.length > 0 ? accords : undefined, color: scordColor });
       continue;
     }
 
     // Harp pedals
     if (el.tagName === 'harp-pedals') {
       const harpContent = el.children;
+      const harpColor = (el.attributes as Record<string, string>)['color'];
       const pedalTunings: { pedalStep: string; pedalAlter: number }[] = [];
       for (const hp of harpContent) {
         if (typeof hp === 'string') continue;
@@ -2528,7 +2581,7 @@ function parseDirectionTypes(elements: XmlChild[]): DirectionType[] {
           }
         }
       }
-      results.push({ kind: 'harp-pedals', pedalTunings: pedalTunings.length > 0 ? pedalTunings : undefined });
+      results.push({ kind: 'harp-pedals', pedalTunings: pedalTunings.length > 0 ? pedalTunings : undefined, color: harpColor });
       continue;
     }
 
@@ -2554,6 +2607,7 @@ function parseDirectionTypes(elements: XmlChild[]): DirectionType[] {
         if (pedalAttrs['default-y']) result.defaultY = parseFloat(pedalAttrs['default-y']);
         if (pedalAttrs['relative-x']) result.relativeX = parseFloat(pedalAttrs['relative-x']);
         if (pedalAttrs['halign']) result.halign = pedalAttrs['halign'];
+        if (pedalAttrs['color']) result.color = pedalAttrs['color'];
         results.push(result);
       }
       continue;
@@ -2566,6 +2620,7 @@ function parseDirectionTypes(elements: XmlChild[]): DirectionType[] {
       if (shiftType === 'up' || shiftType === 'down' || shiftType === 'stop') {
         const result: DirectionType = { kind: 'octave-shift', type: shiftType };
         if (shiftAttrs['size']) result.size = parseInt(shiftAttrs['size'], 10);
+        if (shiftAttrs['color']) result.color = shiftAttrs['color'];
         results.push(result);
       }
       continue;
@@ -2620,10 +2675,13 @@ function parseBarline(elements: XmlChild[], attrs: Record<string, string>): Barl
 
   const barline: Barline = { _id: attrs['id'] || generateId(), location };
 
-  const barStyle = getElementText(elements, 'bar-style');
-  if (barStyle && isValidBarStyle(barStyle)) {
-    barline.barStyle = barStyle;
-  }
+  parseFirstElement(elements, 'bar-style', (c, a) => {
+    const barStyle = extractText(c);
+    if (barStyle && isValidBarStyle(barStyle)) {
+      barline.barStyle = barStyle;
+      if (a['color']) barline.barStyleColor = a['color'];
+    }
+  });
 
   for (const el of elements) {
     if (typeof el === 'string') continue;
@@ -2650,6 +2708,7 @@ function parseBarline(elements: XmlChild[], attrs: Record<string, string>): Barl
         if (endingText) barline.ending.text = endingText;
         if (endingAttrs['default-y']) barline.ending.defaultY = parseFloat(endingAttrs['default-y']);
         if (endingAttrs['end-length']) barline.ending.endLength = parseFloat(endingAttrs['end-length']);
+        if (endingAttrs['color']) barline.ending.color = endingAttrs['color'];
       }
     }
   }
@@ -2779,6 +2838,7 @@ function parseMeasureStyle(elements: XmlChild[], attrs: Record<string, string>):
   const ms: MeasureStyle = {};
 
   if (attrs['number']) ms.number = parseInt(attrs['number'], 10);
+  if (attrs['color']) ms.color = attrs['color'];
 
   const multipleRest = getElementText(elements, 'multiple-rest');
   if (multipleRest) ms.multipleRest = parseInt(multipleRest, 10);
@@ -2826,6 +2886,7 @@ function parseHarmony(elements: XmlChild[], attrs: Record<string, string>): Harm
   if (attrs['default-y']) harmony.defaultY = parseFloat(attrs['default-y']);
   if (attrs['halign']) harmony.halign = attrs['halign'];
   if (attrs['font-size']) harmony.fontSize = attrs['font-size'];
+  if (attrs['color']) harmony.color = attrs['color'];
 
   // Parse root
   const root = getElementContent(elements, 'root');
@@ -2850,6 +2911,7 @@ function parseHarmony(elements: XmlChild[], attrs: Record<string, string>): Harm
       }
       if (kindAttrs['text'] !== undefined) harmony.kindText = kindAttrs['text'];
       if (kindAttrs['halign']) harmony.kindHalign = kindAttrs['halign'];
+      if (kindAttrs['color']) harmony.kindColor = kindAttrs['color'];
       break;
     }
   }
@@ -2956,6 +3018,9 @@ function parseHarmony(elements: XmlChild[], attrs: Record<string, string>): Harm
     }
     if (frameNotes.length > 0) frameObj.frameNotes = frameNotes;
 
+    const frameColor = parseFirstElement(elements, 'frame', (_c, a) => a['color']);
+    if (frameColor) frameObj.color = frameColor;
+
     if (Object.keys(frameObj).length > 0) harmony.frame = frameObj;
   }
 
@@ -2978,6 +3043,7 @@ function parseFiguredBass(elements: XmlChild[], attrs: Record<string, string>): 
   };
 
   if (attrs['parentheses'] === 'yes') fb.parentheses = true;
+  if (attrs['color']) fb.color = attrs['color'];
 
   const duration = getElementText(elements, 'duration');
   if (duration) fb.duration = parseInt(duration, 10);
@@ -3012,8 +3078,9 @@ function parseFiguredBass(elements: XmlChild[], attrs: Record<string, string>): 
         } else if (figEl.tagName === 'extend') {
           const extendAttrs = figEl.attributes as Record<string, string>;
           const extendType = extendAttrs['type'] as 'start' | 'stop' | 'continue' | undefined;
-          if (extendType) {
-            figure.extend = { type: extendType };
+          const extendColor = extendAttrs['color'];
+          if (extendType || extendColor) {
+            figure.extend = { type: extendType, color: extendColor };
           } else {
             figure.extend = true;
           }

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,8 +1,10 @@
 import type {
   Score,
   Measure,
+  MeasureAttributes,
   MeasureEntry,
   NoteEntry,
+  Color,
   Pitch,
   KeySignature,
   TimeSignature,
@@ -6560,6 +6562,245 @@ export function removeCaesura(
   }
 
   return success(result);
+}
+
+// ============================================================
+// Color Operations
+// ============================================================
+
+/**
+ * Kinds of score element `setColor` can paint.
+ *
+ * `'note'` colours the `<note>` element itself, which notation programs treat
+ * as the colour of the whole note. The finer-grained targets below it colour
+ * an individual child element, which overrides the note colour for that part
+ * of the note only.
+ */
+export type ColorTarget =
+  | 'note'
+  | 'notehead'
+  | 'stem'
+  | 'beam'
+  | 'accidental'
+  | 'dot'
+  | 'noteType'
+  | 'notation'
+  | 'lyric'
+  | 'direction'
+  | 'harmony'
+  | 'figuredBass'
+  | 'clef'
+  | 'key'
+  | 'time'
+  | 'barline';
+
+/** Every `ColorTarget`, in a stable order. */
+export const ALL_COLOR_TARGETS: readonly ColorTarget[] = [
+  'note', 'notehead', 'stem', 'beam', 'accidental', 'dot', 'noteType',
+  'notation', 'lyric', 'direction', 'harmony', 'figuredBass',
+  'clef', 'key', 'time', 'barline',
+];
+
+export interface SetColorOptions {
+  /** Colour to apply (e.g. `"#FF0000"`), or `null` to remove it. */
+  color: Color | null;
+  /** Element kinds to paint. Defaults to `['note']`. */
+  targets?: ColorTarget[];
+  /** Restrict to these part indices. Defaults to every part. */
+  partIndices?: number[];
+  /** Restrict to these part IDs (e.g. `'P1'`). Defaults to every part. */
+  partIds?: string[];
+  /** Restrict to these measure numbers. Defaults to every measure. */
+  measureNumbers?: (string | number)[];
+  /**
+   * Only paint notes for which this returns true. Applies to the note targets
+   * (`note`, `notehead`, `stem`, `beam`, `accidental`, `dot`, `noteType`,
+   * `notation`, `lyric`); other targets are unaffected by it.
+   */
+  noteFilter?: (note: NoteEntry) => boolean;
+}
+
+/** Property names that hold a colour somewhere in the Score model. */
+const COLOR_PROPERTY_NAMES = new Set([
+  'color',
+  'nameColor',
+  'abbreviationColor',
+  'groupNameColor',
+  'groupAbbreviationColor',
+  'groupSymbolColor',
+  'noteTypeColor',
+  'dotColor',
+  'textColor',
+  'kindColor',
+  'barStyleColor',
+]);
+
+/** Direction-types with no `color` attribute in the MusicXML schema. */
+const UNCOLORABLE_DIRECTION_KINDS = new Set<DirectionType['kind']>(['image', 'swing']);
+
+function applyColor(target: object | undefined, key: string, color: Color | null): void {
+  if (!target) return;
+  if (color === null) delete (target as Record<string, unknown>)[key];
+  else (target as Record<string, unknown>)[key] = color;
+}
+
+function applyColorToNote(note: NoteEntry, targets: Set<ColorTarget>, color: Color | null): void {
+  if (targets.has('note')) applyColor(note, 'color', color);
+  if (targets.has('noteType') && note.noteType) applyColor(note, 'noteTypeColor', color);
+  if (targets.has('dot') && note.dots) applyColor(note, 'dotColor', color);
+  if (targets.has('notehead')) applyColor(note.notehead, 'color', color);
+  if (targets.has('stem')) applyColor(note.stem, 'color', color);
+  if (targets.has('accidental')) applyColor(note.accidental, 'color', color);
+  if (targets.has('beam') && note.beam) {
+    for (const beam of note.beam) applyColor(beam, 'color', color);
+  }
+  if (targets.has('notation') && note.notations) {
+    // <tuplet> is the one notation element without a color attribute.
+    for (const notation of note.notations) {
+      if (notation.type === 'tuplet') continue;
+      applyColor(notation, 'color', color);
+    }
+  }
+  if (targets.has('lyric') && note.lyrics) {
+    for (const lyric of note.lyrics) {
+      applyColor(lyric, 'color', color);
+      applyColor(lyric, 'textColor', color);
+      if (lyric.textElements) {
+        for (const te of lyric.textElements) applyColor(te, 'color', color);
+      }
+    }
+  }
+}
+
+function applyColorToAttributes(attrs: MeasureAttributes, targets: Set<ColorTarget>, color: Color | null): void {
+  if (targets.has('clef') && attrs.clef) {
+    for (const clef of attrs.clef) applyColor(clef, 'color', color);
+  }
+  if (targets.has('key')) {
+    applyColor(attrs.key, 'color', color);
+    if (attrs.keys) for (const key of attrs.keys) applyColor(key, 'color', color);
+  }
+  if (targets.has('time')) {
+    applyColor(attrs.time, 'color', color);
+    if (attrs.times) for (const time of attrs.times) applyColor(time, 'color', color);
+  }
+}
+
+/**
+ * Set (or clear) the colour of score elements.
+ *
+ * Returns a new Score; the input is left untouched. With no `targets` it
+ * paints the `<note>` elements, which is what "colour these notes" usually
+ * means.
+ *
+ * ```typescript
+ * // every note in measures 5-6 of the first part, red
+ * const marked = setColor(score, {
+ *   color: '#FF0000',
+ *   partIndices: [0],
+ *   measureNumbers: [5, 6],
+ * });
+ *
+ * // a single note found earlier, plus its stem and beams
+ * const one = setColor(score, {
+ *   color: '#0000FF',
+ *   targets: ['note', 'stem', 'beam'],
+ *   noteFilter: (n) => n._id === noteId,
+ * });
+ * ```
+ */
+export function setColor(score: Score, options: SetColorOptions): Score {
+  const { color, targets = ['note'], noteFilter } = options;
+  const targetSet = new Set<ColorTarget>(targets);
+  const partIndexSet = options.partIndices ? new Set(options.partIndices) : undefined;
+  const partIdSet = options.partIds ? new Set(options.partIds) : undefined;
+  const measureNumberSet = options.measureNumbers
+    ? new Set(options.measureNumbers.map(String))
+    : undefined;
+
+  const result = cloneScore(score);
+
+  for (let partIndex = 0; partIndex < result.parts.length; partIndex++) {
+    const part = result.parts[partIndex];
+    if (partIndexSet && !partIndexSet.has(partIndex)) continue;
+    if (partIdSet && !partIdSet.has(part.id)) continue;
+
+    for (const measure of part.measures) {
+      if (measureNumberSet && !measureNumberSet.has(measure.number)) continue;
+
+      if (measure.attributes) {
+        applyColorToAttributes(measure.attributes, targetSet, color);
+      }
+
+      for (const entry of measure.entries) {
+        switch (entry.type) {
+          case 'note':
+            if (!noteFilter || noteFilter(entry)) {
+              applyColorToNote(entry, targetSet, color);
+            }
+            break;
+          case 'attributes':
+            applyColorToAttributes(entry.attributes, targetSet, color);
+            break;
+          case 'direction':
+            if (targetSet.has('direction')) {
+              for (const dirType of entry.directionTypes) {
+                if (UNCOLORABLE_DIRECTION_KINDS.has(dirType.kind)) continue;
+                applyColor(dirType, 'color', color);
+              }
+            }
+            break;
+          case 'harmony':
+            if (targetSet.has('harmony')) {
+              applyColor(entry, 'color', color);
+              applyColor(entry, 'kindColor', color);
+              applyColor(entry.frame, 'color', color);
+            }
+            break;
+          case 'figured-bass':
+            if (targetSet.has('figuredBass')) applyColor(entry, 'color', color);
+            break;
+          default:
+            break;
+        }
+      }
+
+      if (targetSet.has('barline') && measure.barlines) {
+        for (const barline of measure.barlines) {
+          if (barline.barStyle) applyColor(barline, 'barStyleColor', color);
+          applyColor(barline.ending, 'color', color);
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+function stripColors<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) {
+    return value.map(item => stripColors(item)) as unknown as T;
+  }
+  const out: Record<string, unknown> = {};
+  const record = value as Record<string, unknown>;
+  for (const key in record) {
+    const v = record[key];
+    if (v === undefined) continue;
+    if (COLOR_PROPERTY_NAMES.has(key) && typeof v === 'string') continue;
+    out[key] = stripColors(v);
+  }
+  return out as T;
+}
+
+/**
+ * Remove every colour from a score — including the ones this library's
+ * targeted operations do not reach, such as part names and credit words.
+ *
+ * Returns a new Score; the input is left untouched.
+ */
+export function clearColors(score: Score): Score {
+  return stripColors(score);
 }
 
 // ============================================================

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,17 @@
 // ============================================================
+// Color
+// ============================================================
+/**
+ * MusicXML `%color` attribute value.
+ *
+ * The spec defines it as an sRGB hex value with an optional leading alpha
+ * channel: `#RRGGBB` or `#AARRGGBB` (e.g. `"#FF0000"`, `"#80FF0000"`).
+ * The value is carried through parse/serialize verbatim, so any string a
+ * producer wrote survives a round-trip.
+ */
+export type Color = string;
+
+// ============================================================
 // Score (ルート)
 // ============================================================
 export interface Score {
@@ -150,6 +163,8 @@ export interface CreditWords {
   letterSpacing?: string;
   xmlLang?: string;
   xmlSpace?: string;
+  /** MusicXML `color` attribute on `<credit-words>`. */
+  color?: Color;
 }
 
 // PartListEntry is either a PartInfo (score-part) or PartGroup
@@ -161,9 +176,13 @@ export interface PartInfo {
   id: string;
   name?: string;
   namePrintObject?: boolean;
+  /** MusicXML `color` attribute on `<part-name>`. */
+  nameColor?: Color;
   partNameDisplay?: DisplayText[];
   abbreviation?: string;
   abbreviationPrintObject?: boolean;
+  /** MusicXML `color` attribute on `<part-abbreviation>`. */
+  abbreviationColor?: Color;
   partAbbreviationDisplay?: DisplayText[];
   scoreInstruments?: ScoreInstrument[];
   midiDevices?: MidiDevice[];
@@ -178,6 +197,8 @@ export interface DisplayText {
   fontStyle?: string;
   fontWeight?: string;
   xmlSpace?: string;
+  /** MusicXML `color` attribute on `<display-text>`. */
+  color?: Color;
 }
 
 export interface ScoreInstrument {
@@ -212,11 +233,17 @@ export interface PartGroup {
   groupType: 'start' | 'stop';
   number?: number;
   groupName?: string;
+  /** MusicXML `color` attribute on `<group-name>`. */
+  groupNameColor?: Color;
   groupNameDisplay?: DisplayText[];
   groupAbbreviation?: string;
+  /** MusicXML `color` attribute on `<group-abbreviation>`. */
+  groupAbbreviationColor?: Color;
   groupAbbreviationDisplay?: DisplayText[];
   groupSymbol?: 'none' | 'brace' | 'line' | 'bracket' | 'square';
   groupSymbolDefaultX?: number;
+  /** MusicXML `color` attribute on `<group-symbol>`. */
+  groupSymbolColor?: Color;
   groupBarline?: 'yes' | 'no' | 'Mensurstrich';
 }
 
@@ -301,6 +328,8 @@ export interface MeasureStyle {
   measureRepeat?: { type: 'start' | 'stop'; slashes?: number };
   beatRepeat?: { type: 'start' | 'stop'; slashes?: number };
   slash?: { type: 'start' | 'stop'; useDots?: boolean; useStems?: boolean };
+  /** MusicXML `color` attribute on `<measure-style>`. */
+  color?: Color;
 }
 
 export interface TimeSignature {
@@ -313,6 +342,8 @@ export interface TimeSignature {
   symbol?: 'common' | 'cut' | 'single-number' | 'note' | 'dotted-note' | 'normal';
   printObject?: boolean;
   senzaMisura?: boolean; // For unmeasured time
+  /** MusicXML `color` attribute on `<time>`. */
+  color?: Color;
 }
 
 export interface KeySignature {
@@ -322,6 +353,8 @@ export interface KeySignature {
   cancelLocation?: 'left' | 'right' | 'before-barline';
   number?: number; // Staff number for multi-staff keys
   printObject?: boolean;
+  /** MusicXML `color` attribute on `<key>`. */
+  color?: Color;
   // Non-traditional key signatures
   keySteps?: string[];
   keyAlters?: number[];
@@ -341,6 +374,8 @@ export interface Clef {
   clefOctaveChange?: number;
   printObject?: boolean;
   afterBarline?: boolean;
+  /** MusicXML `color` attribute on `<clef>`. */
+  color?: Color;
 }
 
 export interface Transpose {
@@ -353,6 +388,11 @@ export interface Barline {
   _id: string;
   location: 'left' | 'right' | 'middle';
   barStyle?: 'regular' | 'dotted' | 'dashed' | 'heavy' | 'light-light' | 'light-heavy' | 'heavy-light' | 'heavy-heavy' | 'tick' | 'short' | 'none';
+  /**
+   * MusicXML `color` attribute on `<bar-style>`. `<barline>` itself has no
+   * color attribute, so this is only written when `barStyle` is set.
+   */
+  barStyleColor?: Color;
   repeat?: {
     direction: 'forward' | 'backward';
     times?: number;
@@ -364,6 +404,8 @@ export interface Barline {
     text?: string;
     defaultY?: number;
     endLength?: number;
+    /** MusicXML `color` attribute on `<ending>`. */
+    color?: Color;
   };
 }
 
@@ -395,6 +437,13 @@ export interface NoteEntry {
   printSpacing?: boolean;
   printDot?: boolean;
 
+  /**
+   * MusicXML `color` attribute on `<note>`. Notation programs treat this as
+   * the colour of the whole note (head, stem, flags, dots) unless a child
+   * element overrides it.
+   */
+  color?: Color;
+
   // Layout attributes
   defaultX?: number;
   defaultY?: number;
@@ -404,7 +453,15 @@ export interface NoteEntry {
   // Note details
   noteType?: NoteType;
   noteTypeSize?: string;
+  /** MusicXML `color` attribute on the `<type>` element. */
+  noteTypeColor?: Color;
   dots?: number;
+  /**
+   * MusicXML `color` attribute on the `<dot>` elements. Dots are modelled as a
+   * count rather than individually, so this is written to every dot; on parse
+   * it takes the first dot's colour.
+   */
+  dotColor?: Color;
   accidental?: AccidentalInfo;
   stem?: StemInfo;
   notehead?: NoteheadInfo;
@@ -529,6 +586,10 @@ export interface HarmonyEntry {
   defaultY?: number;
   fontSize?: string;
   halign?: string;
+  /** MusicXML `color` attribute on `<harmony>`. */
+  color?: Color;
+  /** MusicXML `color` attribute on the `<kind>` element. */
+  kindColor?: Color;
 }
 
 export interface HarmonyDegree {
@@ -544,6 +605,8 @@ export interface HarmonyFrame {
   firstFretText?: string;
   firstFretLocation?: 'left' | 'right';
   frameNotes?: FrameNote[];
+  /** MusicXML `color` attribute on `<frame>`. */
+  color?: Color;
 }
 
 export interface FrameNote {
@@ -559,13 +622,15 @@ export interface FiguredBassEntry {
   figures: Figure[];
   duration?: number;
   parentheses?: boolean;
+  /** MusicXML `color` attribute on `<figured-bass>`. */
+  color?: Color;
 }
 
 export interface Figure {
   figureNumber?: string;
   prefix?: string;
   suffix?: string;
-  extend?: boolean | { type?: 'start' | 'stop' | 'continue' };
+  extend?: boolean | { type?: 'start' | 'stop' | 'continue'; color?: Color };
 }
 
 // ============================================================
@@ -610,7 +675,8 @@ export interface AccidentalInfo {
   // Positioning attributes
   relativeX?: number;
   relativeY?: number;
-  color?: string;
+  /** MusicXML `color` attribute on `<accidental>`. */
+  color?: Color;
   size?: string;
   fontSize?: string;
 }
@@ -619,12 +685,16 @@ export interface NoteheadInfo {
   value: NoteheadValue;
   filled?: boolean;
   parentheses?: boolean;
+  /** MusicXML `color` attribute on `<notehead>`. */
+  color?: Color;
 }
 
 export interface StemInfo {
   value: 'up' | 'down' | 'none' | 'double';
   defaultX?: number;
   defaultY?: number;
+  /** MusicXML `color` attribute on `<stem>`. */
+  color?: Color;
 }
 
 export type NoteheadValue =
@@ -642,6 +712,8 @@ export interface BeamInfo {
   type: 'begin' | 'continue' | 'end' | 'forward hook' | 'backward hook';
   /** MusicXML <beam> fan attribute, used for feathered beams (羽根状連桁). */
   fan?: 'accel' | 'rit' | 'none';
+  /** MusicXML `color` attribute on `<beam>`. */
+  color?: Color;
 }
 
 // ============================================================
@@ -665,6 +737,14 @@ export type Notation =
 
 export interface BaseNotation {
   placement?: 'above' | 'below';
+  /**
+   * MusicXML `color` attribute on the notation's own element (`<slur>`,
+   * `<staccato>`, `<trill-mark>`, `<fermata>`, ...).
+   *
+   * `<tuplet>` is the one notation without a `color` attribute in the
+   * MusicXML schema, so a colour set on a tuplet notation is not serialized.
+   */
+  color?: Color;
   // For roundtrip: track which <notations> element this came from
   notationsIndex?: number;
   // For roundtrip: track which <articulations> element within <notations>
@@ -690,6 +770,8 @@ export type ArticulationType =
 export interface AccidentalMarkInfo {
   value: Accidental;
   placement?: 'above' | 'below';
+  /** MusicXML `color` attribute on `<accidental-mark>`. */
+  color?: Color;
 }
 
 export interface OrnamentNotation extends BaseNotation {
@@ -845,27 +927,31 @@ export interface OtherNotation extends BaseNotation {
 // ============================================================
 // Direction (強弱、テンポ、etc)
 // ============================================================
+/**
+ * `<image>` and `<swing>` are the only direction-types without a `color`
+ * attribute in the MusicXML schema; every other member below accepts one.
+ */
 export type DirectionType =
-  | { kind: 'dynamics'; value?: DynamicsValue; otherDynamics?: string; defaultX?: number; defaultY?: number; relativeX?: number; halign?: string }
-  | { kind: 'wedge'; type: 'crescendo' | 'diminuendo' | 'stop'; spread?: number; defaultY?: number; relativeX?: number }
-  | { kind: 'metronome'; beatUnit: NoteType; perMinute?: number | string; beatUnitDot?: boolean; beatUnit2?: NoteType; beatUnitDot2?: boolean; parentheses?: boolean; printObject?: boolean; defaultY?: number; fontFamily?: string; fontSize?: string }
-  | { kind: 'words'; text: string; defaultX?: number; defaultY?: number; relativeX?: number; relativeY?: number; fontFamily?: string; fontSize?: string; fontStyle?: string; fontWeight?: string; xmlLang?: string; justify?: string; color?: string; xmlSpace?: string; halign?: string }
-  | { kind: 'rehearsal'; text: string; enclosure?: string; defaultX?: number; defaultY?: number; fontSize?: string; fontWeight?: string }
-  | { kind: 'segno' }
-  | { kind: 'coda' }
-  | { kind: 'pedal'; type: 'start' | 'stop' | 'change' | 'continue'; line?: boolean; defaultY?: number; relativeX?: number; halign?: string }
-  | { kind: 'octave-shift'; type: 'up' | 'down' | 'stop'; size?: number }
-  | { kind: 'bracket'; type: 'start' | 'stop' | 'continue'; number?: number; lineEnd?: 'up' | 'down' | 'both' | 'arrow' | 'none'; lineType?: 'solid' | 'dashed' | 'dotted' | 'wavy'; defaultY?: number; relativeX?: number }
-  | { kind: 'dashes'; type: 'start' | 'stop' | 'continue'; number?: number; dashLength?: number; defaultY?: number; spaceLength?: number }
-  | { kind: 'accordion-registration'; high?: boolean; middle?: number | string; middlePresent?: boolean; low?: boolean }
+  | { kind: 'dynamics'; value?: DynamicsValue; otherDynamics?: string; defaultX?: number; defaultY?: number; relativeX?: number; halign?: string; color?: Color }
+  | { kind: 'wedge'; type: 'crescendo' | 'diminuendo' | 'stop'; spread?: number; defaultY?: number; relativeX?: number; color?: Color }
+  | { kind: 'metronome'; beatUnit: NoteType; perMinute?: number | string; beatUnitDot?: boolean; beatUnit2?: NoteType; beatUnitDot2?: boolean; parentheses?: boolean; printObject?: boolean; defaultY?: number; fontFamily?: string; fontSize?: string; color?: Color }
+  | { kind: 'words'; text: string; defaultX?: number; defaultY?: number; relativeX?: number; relativeY?: number; fontFamily?: string; fontSize?: string; fontStyle?: string; fontWeight?: string; xmlLang?: string; justify?: string; color?: Color; xmlSpace?: string; halign?: string }
+  | { kind: 'rehearsal'; text: string; enclosure?: string; defaultX?: number; defaultY?: number; fontSize?: string; fontWeight?: string; color?: Color }
+  | { kind: 'segno'; color?: Color }
+  | { kind: 'coda'; color?: Color }
+  | { kind: 'pedal'; type: 'start' | 'stop' | 'change' | 'continue'; line?: boolean; defaultY?: number; relativeX?: number; halign?: string; color?: Color }
+  | { kind: 'octave-shift'; type: 'up' | 'down' | 'stop'; size?: number; color?: Color }
+  | { kind: 'bracket'; type: 'start' | 'stop' | 'continue'; number?: number; lineEnd?: 'up' | 'down' | 'both' | 'arrow' | 'none'; lineType?: 'solid' | 'dashed' | 'dotted' | 'wavy'; defaultY?: number; relativeX?: number; color?: Color }
+  | { kind: 'dashes'; type: 'start' | 'stop' | 'continue'; number?: number; dashLength?: number; defaultY?: number; spaceLength?: number; color?: Color }
+  | { kind: 'accordion-registration'; high?: boolean; middle?: number | string; middlePresent?: boolean; low?: boolean; color?: Color }
   | { kind: 'swing'; straight?: boolean; first?: number; second?: number; swingType?: NoteType }
-  | { kind: 'eyeglasses' }
-  | { kind: 'damp' }
-  | { kind: 'damp-all' }
-  | { kind: 'scordatura'; accords?: Accord[] }
-  | { kind: 'harp-pedals'; pedalTunings?: PedalTuning[] }
+  | { kind: 'eyeglasses'; color?: Color }
+  | { kind: 'damp'; color?: Color }
+  | { kind: 'damp-all'; color?: Color }
+  | { kind: 'scordatura'; accords?: Accord[]; color?: Color }
+  | { kind: 'harp-pedals'; pedalTunings?: PedalTuning[]; color?: Color }
   | { kind: 'image'; source?: string; type?: string }
-  | { kind: 'other-direction'; text: string; defaultX?: number; defaultY?: number; halign?: string; printObject?: boolean };
+  | { kind: 'other-direction'; text: string; defaultX?: number; defaultY?: number; halign?: string; printObject?: boolean; color?: Color };
 
 export interface Accord {
   string: number;
@@ -891,6 +977,8 @@ export type DynamicsValue =
 export interface LyricTextElement {
   text: string;
   syllabic?: 'single' | 'begin' | 'middle' | 'end';
+  /** MusicXML `color` attribute on this `<text>` element. */
+  color?: Color;
 }
 
 export interface Lyric {
@@ -900,13 +988,21 @@ export interface Lyric {
   text: string;
   textElements?: LyricTextElement[]; // For multiple text/elision pairs
   elision?: boolean; // Simple flag for single elision
-  extend?: boolean | { type?: 'start' | 'stop' | 'continue' };
+  extend?: boolean | { type?: 'start' | 'stop' | 'continue'; color?: Color };
   endLine?: boolean;
   endParagraph?: boolean;
   defaultY?: number;
   relativeX?: number;
   justify?: string;
   placement?: 'above' | 'below';
+  /** MusicXML `color` attribute on `<lyric>`. */
+  color?: Color;
+  /**
+   * MusicXML `color` attribute on the `<text>` element. When a lyric holds
+   * several text elements (elisions), each one's colour lives on
+   * `textElements[i].color` and this is the first element's colour.
+   */
+  textColor?: Color;
 }
 
 // ============================================================

--- a/tests/color.test.ts
+++ b/tests/color.test.ts
@@ -1,0 +1,673 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  parse,
+  serialize,
+  setColor,
+  clearColors,
+  ALL_COLOR_TARGETS,
+  type Score,
+  type NoteEntry,
+  type DirectionEntry,
+  type HarmonyEntry,
+  type FiguredBassEntry,
+  type PartGroup,
+} from '../src';
+
+const RED = '#FF0000';
+const BLUE = '#0000FF';
+const GREEN = '#00FF00';
+/** MusicXML also allows an alpha channel: #AARRGGBB. */
+const TRANSLUCENT_RED = '#80FF0000';
+
+/**
+ * Wrap measure content in a minimal score-partwise document.
+ */
+function scoreXml(measureBody: string, opts: { partList?: string; extra?: string } = {}): string {
+  const partList = opts.partList ?? `
+    <score-part id="P1">
+      <part-name>Music</part-name>
+    </score-part>`;
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  ${opts.extra ?? ''}
+  <part-list>${partList}
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+      </attributes>
+${measureBody}
+    </measure>
+  </part>
+</score-partwise>`;
+}
+
+/** Parse → serialize → parse, so we assert the colour survives both directions. */
+function roundtrip(xml: string): { first: Score; second: Score; xml: string } {
+  const first = parse(xml);
+  const serialized = serialize(first);
+  return { first, second: parse(serialized), xml: serialized };
+}
+
+function firstNote(score: Score): NoteEntry {
+  const note = score.parts[0].measures[0].entries.find(e => e.type === 'note');
+  if (!note || note.type !== 'note') throw new Error('no note in measure');
+  return note;
+}
+
+function firstDirection(score: Score): DirectionEntry {
+  const dir = score.parts[0].measures[0].entries.find(e => e.type === 'direction');
+  if (!dir || dir.type !== 'direction') throw new Error('no direction in measure');
+  return dir;
+}
+
+describe('Color: note-level elements', () => {
+  const NOTE_XML = scoreXml(`      <note color="${RED}">
+        <pitch><step>C</step><alter>1</alter><octave>4</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type color="${BLUE}">eighth</type>
+        <dot color="${GREEN}"/>
+        <accidental color="${RED}">sharp</accidental>
+        <stem color="${BLUE}">up</stem>
+        <notehead color="${GREEN}">diamond</notehead>
+        <beam number="1" color="${RED}">begin</beam>
+      </note>`);
+
+  it('parses colour on note, type, dot, accidental, stem, notehead and beam', () => {
+    const note = firstNote(parse(NOTE_XML));
+
+    expect(note.color).toBe(RED);
+    expect(note.noteTypeColor).toBe(BLUE);
+    expect(note.dotColor).toBe(GREEN);
+    expect(note.accidental?.color).toBe(RED);
+    expect(note.stem?.color).toBe(BLUE);
+    expect(note.notehead?.color).toBe(GREEN);
+    expect(note.beam?.[0].color).toBe(RED);
+  });
+
+  it('round-trips every note-level colour', () => {
+    const { second } = roundtrip(NOTE_XML);
+    const note = second.parts[0].measures[0].entries[0] as NoteEntry;
+
+    expect(note.color).toBe(RED);
+    expect(note.noteTypeColor).toBe(BLUE);
+    expect(note.dotColor).toBe(GREEN);
+    expect(note.accidental?.color).toBe(RED);
+    expect(note.stem?.color).toBe(BLUE);
+    expect(note.notehead?.color).toBe(GREEN);
+    expect(note.beam?.[0].color).toBe(RED);
+  });
+
+  it('preserves the ARGB form of a colour verbatim', () => {
+    const xml = scoreXml(`      <note color="${TRANSLUCENT_RED}">
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>`);
+    const { second, xml: serialized } = roundtrip(xml);
+
+    expect(serialized).toContain(`color="${TRANSLUCENT_RED}"`);
+    expect(firstNote(second).color).toBe(TRANSLUCENT_RED);
+  });
+
+  it('leaves uncoloured notes without a color attribute', () => {
+    const xml = scoreXml(`      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>`);
+    const { second, xml: serialized } = roundtrip(xml);
+
+    expect(serialized).not.toContain('color=');
+    expect(firstNote(second).color).toBeUndefined();
+  });
+});
+
+describe('Color: notations', () => {
+  const NOTATIONS_XML = scoreXml(`      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>2</duration>
+        <type>half</type>
+        <notations>
+          <tied type="start" color="${RED}"/>
+          <slur number="1" type="start" color="${BLUE}"/>
+          <articulations>
+            <staccato color="${GREEN}"/>
+            <accent color="${RED}"/>
+          </articulations>
+          <ornaments>
+            <trill-mark color="${BLUE}"/>
+            <tremolo type="single" color="${GREEN}">3</tremolo>
+            <wavy-line type="start" color="${RED}"/>
+            <accidental-mark color="${BLUE}">sharp</accidental-mark>
+          </ornaments>
+          <technical>
+            <fingering color="${GREEN}">3</fingering>
+            <up-bow color="${RED}"/>
+          </technical>
+          <dynamics color="${BLUE}"><ff/></dynamics>
+          <fermata color="${GREEN}">normal</fermata>
+          <arpeggiate color="${RED}"/>
+          <glissando type="start" color="${BLUE}"/>
+          <slide type="start" color="${GREEN}"/>
+        </notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>2</duration>
+        <type>half</type>
+        <notations>
+          <non-arpeggiate type="bottom" color="${RED}"/>
+          <accidental-mark color="${GREEN}">flat</accidental-mark>
+        </notations>
+      </note>`);
+
+  it('round-trips colour on every notation that supports it', () => {
+    const { second } = roundtrip(NOTATIONS_XML);
+    const entries = second.parts[0].measures[0].entries.filter(e => e.type === 'note') as NoteEntry[];
+    const notations = [...(entries[0].notations ?? []), ...(entries[1].notations ?? [])];
+
+    // Every notation parsed here carries a colour, so none may be lost.
+    expect(notations.length).toBeGreaterThan(0);
+    for (const notation of notations) {
+      expect(notation.color, `${notation.type} lost its colour`).toBeDefined();
+    }
+
+    const byType = (t: string) => notations.find(n => n.type === t);
+    expect(byType('tied')?.color).toBe(RED);
+    expect(byType('slur')?.color).toBe(BLUE);
+    expect(byType('dynamics')?.color).toBe(BLUE);
+    expect(byType('fermata')?.color).toBe(GREEN);
+    expect(byType('arpeggiate')?.color).toBe(RED);
+    expect(byType('glissando')?.color).toBe(BLUE);
+    expect(byType('slide')?.color).toBe(GREEN);
+    expect(byType('non-arpeggiate')?.color).toBe(RED);
+    expect(byType('accidental-mark')?.color).toBe(GREEN);
+  });
+
+  it('keeps the ornament accidental-mark colour', () => {
+    const { second, xml } = roundtrip(NOTATIONS_XML);
+    const note = second.parts[0].measures[0].entries[0] as NoteEntry;
+    const ornament = note.notations?.find(n => n.type === 'ornament' && n.accidentalMarks);
+
+    expect(xml).toContain(`<accidental-mark color="${BLUE}">sharp</accidental-mark>`);
+    expect(
+      ornament && ornament.type === 'ornament' ? ornament.accidentalMarks?.[0].color : undefined
+    ).toBe(BLUE);
+  });
+
+  it('does not write a color attribute on <tuplet>, which has none in the schema', () => {
+    const score = parse(scoreXml(`      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+        <notations><tuplet type="start" number="1"/></notations>
+      </note>`));
+    const note = firstNote(score);
+    const tuplet = note.notations?.find(n => n.type === 'tuplet');
+    if (tuplet) tuplet.color = RED;
+
+    expect(serialize(score)).not.toMatch(/<tuplet[^>]*color=/);
+  });
+});
+
+describe('Color: lyrics', () => {
+  it('round-trips lyric, text and extend colours', () => {
+    const xml = scoreXml(`      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <lyric number="1" color="${RED}">
+          <syllabic>single</syllabic>
+          <text color="${BLUE}">la</text>
+          <extend type="start" color="${GREEN}"/>
+        </lyric>
+      </note>`);
+    const { second, xml: serialized } = roundtrip(xml);
+    const lyric = firstNote(second).lyrics?.[0];
+
+    expect(lyric?.color).toBe(RED);
+    expect(lyric?.textColor).toBe(BLUE);
+    expect(typeof lyric?.extend === 'object' ? lyric.extend.color : undefined).toBe(GREEN);
+    expect(serialized).toContain(`<text color="${BLUE}">la</text>`);
+  });
+
+  it('keeps per-element colours across an elision', () => {
+    const xml = scoreXml(`      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <lyric number="1">
+          <syllabic>single</syllabic>
+          <text color="${RED}">a</text>
+          <elision/>
+          <text color="${BLUE}">b</text>
+        </lyric>
+      </note>`);
+    const { second } = roundtrip(xml);
+    const lyric = firstNote(second).lyrics?.[0];
+
+    expect(lyric?.textElements?.map(t => t.color)).toEqual([RED, BLUE]);
+  });
+});
+
+describe('Color: directions', () => {
+  const DIRECTIONS_XML = scoreXml(`      <direction placement="above">
+        <direction-type><words color="${RED}">dolce</words></direction-type>
+      </direction>
+      <direction>
+        <direction-type><dynamics color="${BLUE}"><p/></dynamics></direction-type>
+      </direction>
+      <direction>
+        <direction-type><wedge type="crescendo" color="${GREEN}"/></direction-type>
+      </direction>
+      <direction>
+        <direction-type><metronome color="${RED}"><beat-unit>quarter</beat-unit><per-minute>120</per-minute></metronome></direction-type>
+      </direction>
+      <direction>
+        <direction-type><rehearsal color="${BLUE}">A</rehearsal></direction-type>
+      </direction>
+      <direction>
+        <direction-type><segno color="${GREEN}"/></direction-type>
+      </direction>
+      <direction>
+        <direction-type><coda color="${RED}"/></direction-type>
+      </direction>
+      <direction>
+        <direction-type><pedal type="start" color="${BLUE}"/></direction-type>
+      </direction>
+      <direction>
+        <direction-type><octave-shift type="down" size="8" color="${GREEN}"/></direction-type>
+      </direction>
+      <direction>
+        <direction-type><bracket type="start" line-end="down" color="${RED}"/></direction-type>
+      </direction>
+      <direction>
+        <direction-type><dashes type="start" color="${BLUE}"/></direction-type>
+      </direction>
+      <direction>
+        <direction-type><eyeglasses color="${GREEN}"/></direction-type>
+      </direction>
+      <direction>
+        <direction-type><damp color="${RED}"/></direction-type>
+      </direction>
+      <direction>
+        <direction-type><damp-all color="${BLUE}"/></direction-type>
+      </direction>
+      <direction>
+        <direction-type><accordion-registration color="${GREEN}"><accordion-high/></accordion-registration></direction-type>
+      </direction>
+      <direction>
+        <direction-type><harp-pedals color="${RED}"><pedal-tuning><pedal-step>D</pedal-step><pedal-alter>0</pedal-alter></pedal-tuning></harp-pedals></direction-type>
+      </direction>
+      <direction>
+        <direction-type><scordatura color="${BLUE}"><accord string="1"><tuning-step>E</tuning-step><tuning-octave>5</tuning-octave></accord></scordatura></direction-type>
+      </direction>
+      <direction>
+        <direction-type><other-direction color="${GREEN}">custom</other-direction></direction-type>
+      </direction>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>`);
+
+  it('round-trips colour on every colourable direction-type', () => {
+    const { second } = roundtrip(DIRECTIONS_XML);
+    const dirTypes = second.parts[0].measures[0].entries
+      .filter((e): e is DirectionEntry => e.type === 'direction')
+      .flatMap(d => d.directionTypes);
+
+    expect(dirTypes.length).toBe(18);
+    for (const dirType of dirTypes) {
+      expect(
+        (dirType as { color?: string }).color,
+        `direction-type "${dirType.kind}" lost its colour`
+      ).toBeDefined();
+    }
+  });
+
+  it('keeps the words colour it already supported', () => {
+    const { second } = roundtrip(DIRECTIONS_XML);
+    const words = firstDirection(second).directionTypes[0];
+
+    expect(words.kind).toBe('words');
+    expect((words as { color?: string }).color).toBe(RED);
+  });
+});
+
+describe('Color: attributes, barlines, harmony and figured bass', () => {
+  it('round-trips key, time and clef colours', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Music</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key color="${RED}"><fifths>2</fifths></key>
+        <time color="${BLUE}"><beats>3</beats><beat-type>4</beat-type></time>
+        <clef color="${GREEN}"><sign>G</sign><line>2</line></clef>
+        <measure-style color="${RED}"><multiple-rest>4</multiple-rest></measure-style>
+      </attributes>
+    </measure>
+  </part>
+</score-partwise>`;
+    const { second } = roundtrip(xml);
+    const attrs = second.parts[0].measures[0].attributes!;
+
+    expect(attrs.key?.color).toBe(RED);
+    expect(attrs.time?.color).toBe(BLUE);
+    expect(attrs.clef?.[0].color).toBe(GREEN);
+    expect(attrs.measureStyle?.[0].color).toBe(RED);
+  });
+
+  it('round-trips bar-style and ending colours', () => {
+    const xml = scoreXml(`      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+      <barline location="right">
+        <bar-style color="${RED}">light-heavy</bar-style>
+        <ending number="1" type="stop" color="${BLUE}"/>
+      </barline>`);
+    const { second, xml: serialized } = roundtrip(xml);
+    const barline = second.parts[0].measures[0].barlines?.[0];
+
+    expect(barline?.barStyleColor).toBe(RED);
+    expect(barline?.ending?.color).toBe(BLUE);
+    expect(serialized).toContain(`<bar-style color="${RED}">light-heavy</bar-style>`);
+  });
+
+  it('round-trips harmony, kind, frame and figured-bass colours', () => {
+    const xml = scoreXml(`      <harmony color="${RED}">
+        <root><root-step>C</root-step></root>
+        <kind color="${BLUE}">major</kind>
+        <frame color="${GREEN}">
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+        </frame>
+      </harmony>
+      <figured-bass color="${RED}">
+        <figure>
+          <figure-number>6</figure-number>
+          <extend type="start" color="${BLUE}"/>
+        </figure>
+      </figured-bass>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>`);
+    const { second } = roundtrip(xml);
+    const entries = second.parts[0].measures[0].entries;
+    const harmony = entries.find((e): e is HarmonyEntry => e.type === 'harmony')!;
+    const figuredBass = entries.find((e): e is FiguredBassEntry => e.type === 'figured-bass')!;
+    const extend = figuredBass.figures[0].extend;
+
+    expect(harmony.color).toBe(RED);
+    expect(harmony.kindColor).toBe(BLUE);
+    expect(harmony.frame?.color).toBe(GREEN);
+    expect(figuredBass.color).toBe(RED);
+    expect(typeof extend === 'object' ? extend.color : undefined).toBe(BLUE);
+  });
+});
+
+describe('Color: header elements', () => {
+  it('round-trips part-list, credit and display-text colours', () => {
+    const xml = scoreXml(`      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>`, {
+      extra: `<credit page="1"><credit-words color="${RED}">Title</credit-words></credit>`,
+      partList: `
+    <part-group type="start" number="1">
+      <group-name color="${RED}">Strings</group-name>
+      <group-abbreviation color="${BLUE}">Str.</group-abbreviation>
+      <group-symbol color="${GREEN}">bracket</group-symbol>
+    </part-group>
+    <score-part id="P1">
+      <part-name color="${BLUE}">Violin</part-name>
+      <part-name-display><display-text color="${GREEN}">Vln.</display-text></part-name-display>
+      <part-abbreviation color="${RED}">Vln.</part-abbreviation>
+    </score-part>
+    <part-group type="stop" number="1"/>`,
+    });
+    const { second } = roundtrip(xml);
+    const group = second.partList.find((e): e is PartGroup => e.type === 'part-group')!;
+    const part = second.partList.find(e => e.type === 'score-part')!;
+
+    expect(second.credits?.[0].creditWords?.[0].color).toBe(RED);
+    expect(group.groupNameColor).toBe(RED);
+    expect(group.groupAbbreviationColor).toBe(BLUE);
+    expect(group.groupSymbolColor).toBe(GREEN);
+    expect(part.type === 'score-part' && part.nameColor).toBe(BLUE);
+    expect(part.type === 'score-part' && part.abbreviationColor).toBe(RED);
+    expect(part.type === 'score-part' && part.partNameDisplay?.[0].color).toBe(GREEN);
+  });
+});
+
+describe('Color: fixture', () => {
+  it('keeps every color attribute of the color-elements fixture', () => {
+    const path = join(__dirname, 'fixtures', 'color-elements.musicxml');
+    const source = readFileSync(path, 'utf8');
+    const serialized = serialize(parse(source));
+
+    const count = (s: string) => (s.match(/\scolor="[^"]*"/g) ?? []).length;
+    expect(count(source)).toBeGreaterThan(0);
+    expect(count(serialized)).toBe(count(source));
+  });
+});
+
+// ============================================================
+// Operations
+// ============================================================
+
+const OPERATIONS_XML = scoreXml(`      <direction placement="above">
+        <direction-type><words>dolce</words></direction-type>
+      </direction>
+      <harmony>
+        <root><root-step>C</root-step></root>
+        <kind>major</kind>
+      </harmony>
+      <note>
+        <pitch><step>C</step><alter>1</alter><octave>4</octave></pitch>
+        <duration>1</duration>
+        <type>eighth</type>
+        <dot/>
+        <accidental>sharp</accidental>
+        <stem>up</stem>
+        <notehead>normal</notehead>
+        <beam number="1">begin</beam>
+        <lyric number="1"><syllabic>single</syllabic><text>la</text></lyric>
+        <notations><articulations><staccato/></articulations></notations>
+      </note>
+      <note>
+        <rest/>
+        <duration>3</duration>
+        <type>half</type>
+        <dot/>
+      </note>
+      <barline location="right"><bar-style>light-heavy</bar-style></barline>`);
+
+describe('setColor', () => {
+  it('colours the <note> elements by default and leaves the rest alone', () => {
+    const score = parse(OPERATIONS_XML);
+    const colored = setColor(score, { color: RED });
+    const notes = colored.parts[0].measures[0].entries.filter((e): e is NoteEntry => e.type === 'note');
+
+    expect(notes.map(n => n.color)).toEqual([RED, RED]);
+    expect(notes[0].stem?.color).toBeUndefined();
+    expect(notes[0].notehead?.color).toBeUndefined();
+  });
+
+  it('colours rests as well as pitched notes', () => {
+    const colored = setColor(parse(OPERATIONS_XML), { color: RED });
+    const rest = colored.parts[0].measures[0].entries
+      .filter((e): e is NoteEntry => e.type === 'note')
+      .find(n => n.rest);
+
+    expect(rest?.color).toBe(RED);
+  });
+
+  it('does not mutate the input score', () => {
+    const score = parse(OPERATIONS_XML);
+    setColor(score, { color: RED, targets: [...ALL_COLOR_TARGETS] });
+
+    expect(firstNote(score).color).toBeUndefined();
+  });
+
+  it('colours the requested note sub-elements', () => {
+    const colored = setColor(parse(OPERATIONS_XML), {
+      color: BLUE,
+      targets: ['notehead', 'stem', 'beam', 'accidental', 'dot', 'noteType', 'notation', 'lyric'],
+    });
+    const note = firstNote(colored);
+
+    expect(note.color).toBeUndefined();
+    expect(note.notehead?.color).toBe(BLUE);
+    expect(note.stem?.color).toBe(BLUE);
+    expect(note.beam?.[0].color).toBe(BLUE);
+    expect(note.accidental?.color).toBe(BLUE);
+    expect(note.dotColor).toBe(BLUE);
+    expect(note.noteTypeColor).toBe(BLUE);
+    expect(note.notations?.[0].color).toBe(BLUE);
+    expect(note.lyrics?.[0].color).toBe(BLUE);
+    expect(note.lyrics?.[0].textColor).toBe(BLUE);
+  });
+
+  it('colours directions, harmony, attributes and barlines', () => {
+    const colored = setColor(parse(OPERATIONS_XML), {
+      color: GREEN,
+      targets: ['direction', 'harmony', 'clef', 'key', 'time', 'barline'],
+    });
+    const measure = colored.parts[0].measures[0];
+    const direction = measure.entries.find((e): e is DirectionEntry => e.type === 'direction')!;
+    const harmony = measure.entries.find((e): e is HarmonyEntry => e.type === 'harmony')!;
+
+    expect((direction.directionTypes[0] as { color?: string }).color).toBe(GREEN);
+    expect(harmony.color).toBe(GREEN);
+    expect(harmony.kindColor).toBe(GREEN);
+    expect(measure.barlines?.[0].barStyleColor).toBe(GREEN);
+  });
+
+  it('honours noteFilter', () => {
+    const score = parse(OPERATIONS_XML);
+    const target = firstNote(score);
+    const colored = setColor(score, { color: RED, noteFilter: n => n._id === target._id });
+    const notes = colored.parts[0].measures[0].entries.filter((e): e is NoteEntry => e.type === 'note');
+
+    expect(notes[0].color).toBe(RED);
+    expect(notes[1].color).toBeUndefined();
+  });
+
+  it('honours partIndices, partIds and measureNumbers', () => {
+    const score = parse(OPERATIONS_XML);
+
+    expect(firstNote(setColor(score, { color: RED, partIndices: [1] })).color).toBeUndefined();
+    expect(firstNote(setColor(score, { color: RED, partIndices: [0] })).color).toBe(RED);
+    expect(firstNote(setColor(score, { color: RED, partIds: ['P2'] })).color).toBeUndefined();
+    expect(firstNote(setColor(score, { color: RED, partIds: ['P1'] })).color).toBe(RED);
+    expect(firstNote(setColor(score, { color: RED, measureNumbers: [2] })).color).toBeUndefined();
+    expect(firstNote(setColor(score, { color: RED, measureNumbers: [1] })).color).toBe(RED);
+    expect(firstNote(setColor(score, { color: RED, measureNumbers: ['1'] })).color).toBe(RED);
+  });
+
+  it('removes the colour when passed null', () => {
+    const colored = setColor(parse(OPERATIONS_XML), { color: RED, targets: ['note', 'stem'] });
+    const cleared = setColor(colored, { color: null, targets: ['note', 'stem'] });
+    const note = firstNote(cleared);
+
+    expect('color' in note).toBe(false);
+    expect(note.stem?.color).toBeUndefined();
+  });
+
+  it('survives serialization', () => {
+    const colored = setColor(parse(OPERATIONS_XML), {
+      color: RED,
+      targets: [...ALL_COLOR_TARGETS],
+    });
+    const reparsed = parse(serialize(colored));
+    const note = firstNote(reparsed);
+
+    expect(note.color).toBe(RED);
+    expect(note.stem?.color).toBe(RED);
+    expect(note.notations?.[0].color).toBe(RED);
+    expect(reparsed.parts[0].measures[0].barlines?.[0].barStyleColor).toBe(RED);
+  });
+
+  it('never writes an unsupported colour attribute', () => {
+    // <image> and <swing> have no color attribute; painting everything must
+    // still produce a document without one on them.
+    const xml = scoreXml(`      <direction>
+        <direction-type><image source="x.png" type="application/png"/></direction-type>
+      </direction>
+      <direction>
+        <direction-type><swing><first>2</first><second>1</second></swing></direction-type>
+      </direction>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>`);
+    const serialized = serialize(setColor(parse(xml), { color: RED, targets: ['direction'] }));
+
+    expect(serialized).not.toMatch(/<image[^>]*color=/);
+    expect(serialized).not.toMatch(/<swing[^>]*color=/);
+  });
+});
+
+describe('clearColors', () => {
+  it('removes every colour, including header colours setColor does not reach', () => {
+    const xml = scoreXml(`      <note color="${RED}">
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type color="${BLUE}">whole</type>
+        <stem color="${GREEN}">up</stem>
+        <notations><slur number="1" type="start" color="${RED}"/></notations>
+      </note>`, {
+      extra: `<credit><credit-words color="${RED}">Title</credit-words></credit>`,
+      partList: `
+    <score-part id="P1">
+      <part-name color="${BLUE}">Violin</part-name>
+    </score-part>`,
+    });
+    const cleared = clearColors(parse(xml));
+
+    expect(serialize(cleared)).not.toContain('color=');
+  });
+
+  it('does not mutate the input score', () => {
+    const score = parse(scoreXml(`      <note color="${RED}">
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>`));
+    clearColors(score);
+
+    expect(firstNote(score).color).toBe(RED);
+  });
+
+  it('leaves the rest of the score intact', () => {
+    const score = parse(scoreXml(`      <note color="${RED}">
+        <pitch><step>C</step><alter>1</alter><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <lyric number="1" color="${BLUE}"><text color="${GREEN}">la</text></lyric>
+      </note>`));
+    const cleared = clearColors(score);
+    const note = firstNote(cleared);
+
+    expect(note.pitch).toEqual({ step: 'C', octave: 4, alter: 1 });
+    expect(note.noteType).toBe('whole');
+    expect(note.lyrics?.[0].text).toBe('la');
+    expect(note.lyrics?.[0].color).toBeUndefined();
+  });
+});

--- a/tests/fixtures/color-elements.musicxml
+++ b/tests/fixtures/color-elements.musicxml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<!--
+  Hand-written fixture exercising the MusicXML `color` attribute across every
+  element kind the Score model represents. Colors use both the #RRGGBB and the
+  #AARRGGBB (alpha) spellings.
+-->
+<score-partwise version="4.0">
+  <work>
+    <work-title>Colored elements</work-title>
+  </work>
+  <credit page="1">
+    <credit-words default-x="600" default-y="1500" font-size="24" color="#FF0000">Colored elements</credit-words>
+  </credit>
+  <part-list>
+    <part-group type="start" number="1">
+      <group-name color="#FF0000">Group</group-name>
+      <group-abbreviation color="#00FF00">Grp.</group-abbreviation>
+      <group-symbol color="#0000FF">bracket</group-symbol>
+    </part-group>
+    <score-part id="P1">
+      <part-name color="#008000">Colored</part-name>
+      <part-name-display>
+        <display-text color="#800080">Colored</display-text>
+      </part-name-display>
+      <part-abbreviation color="#808000">Col.</part-abbreviation>
+    </score-part>
+    <part-group type="stop" number="1"/>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>2</divisions>
+        <key color="#FF0000">
+          <fifths>1</fifths>
+          <mode>major</mode>
+        </key>
+        <time color="#00AA00">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef color="#0000FF">
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <direction placement="above">
+        <direction-type>
+          <words color="#FF8000">dolce</words>
+        </direction-type>
+      </direction>
+      <direction placement="below">
+        <direction-type>
+          <dynamics color="#FF0000">
+            <p/>
+          </dynamics>
+        </direction-type>
+      </direction>
+      <direction placement="below">
+        <direction-type>
+          <wedge type="crescendo" color="#80FF0000"/>
+        </direction-type>
+      </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome color="#123456">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>96</per-minute>
+          </metronome>
+        </direction-type>
+      </direction>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal color="#0000FF">A</rehearsal>
+        </direction-type>
+      </direction>
+      <direction placement="above">
+        <direction-type>
+          <segno color="#FF00FF"/>
+        </direction-type>
+      </direction>
+      <harmony color="#FF0000">
+        <root>
+          <root-step>G</root-step>
+        </root>
+        <kind color="#00FF00">dominant</kind>
+        <frame color="#0000FF">
+          <frame-strings>6</frame-strings>
+          <frame-frets>4</frame-frets>
+        </frame>
+      </harmony>
+      <note color="#FF0000">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type color="#00FF00">eighth</type>
+        <accidental color="#0000FF">sharp</accidental>
+        <stem color="#FF00FF">up</stem>
+        <notehead color="#00FFFF">diamond</notehead>
+        <beam number="1" color="#FFFF00">begin</beam>
+        <notations>
+          <tied type="start" color="#FF0000"/>
+          <slur number="1" type="start" color="#00FF00"/>
+          <articulations>
+            <staccato color="#0000FF"/>
+            <accent color="#FF00FF"/>
+          </articulations>
+          <ornaments>
+            <trill-mark color="#00FFFF"/>
+            <accidental-mark color="#FFFF00">sharp</accidental-mark>
+          </ornaments>
+          <technical>
+            <fingering color="#FF0000">3</fingering>
+          </technical>
+          <fermata color="#00FF00">normal</fermata>
+          <arpeggiate color="#0000FF"/>
+        </notations>
+        <lyric number="1" color="#FF0000">
+          <syllabic>begin</syllabic>
+          <text color="#00FF00">co</text>
+          <extend type="start" color="#0000FF"/>
+        </lyric>
+      </note>
+      <note color="#80000080">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <beam number="1" color="#FFFF00">end</beam>
+        <notations>
+          <tied type="stop" color="#FF0000"/>
+          <slur number="1" type="stop" color="#00FF00"/>
+          <glissando type="start" color="#123456"/>
+        </notations>
+        <lyric number="1">
+          <syllabic>end</syllabic>
+          <text color="#00AA00">lor</text>
+        </lyric>
+      </note>
+      <figured-bass color="#FF0000">
+        <figure>
+          <figure-number>6</figure-number>
+          <extend type="start" color="#0000FF"/>
+        </figure>
+      </figured-bass>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type color="#008080">half</type>
+        <dot color="#008080"/>
+        <stem color="#008080">up</stem>
+      </note>
+      <barline location="right">
+        <bar-style color="#FF0000">light-heavy</bar-style>
+        <ending number="1" type="stop" color="#0000FF"/>
+      </barline>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
## Summary

MusicXML's `color` attribute was only carried on `<accidental>` and `<words>`. Everywhere else it was dropped on parse and never emitted on serialize, so a coloured score came back monochrome.

This PR makes colour a first-class, round-tripping property of the `Score` model on every element the model represents, and adds operations for editing colours.

## Round-trip coverage

| Area | Elements now carrying `color` |
|------|-------------------------------|
| Note | `<note>`, `<type>`, `<dot>`, `<stem>`, `<notehead>`, `<beam>` (`<accidental>` already worked) |
| Notations | ties, slurs, articulations, ornaments (incl. `<accidental-mark>`, `<wavy-line>`, `<tremolo>`), technicals, dynamics, fermatas, arpeggios, glissandi, slides |
| Lyrics | `<lyric>`, each `<text>` (including across elisions), `<extend>` |
| Directions | dynamics, wedge, metronome, rehearsal, segno, coda, pedal, octave-shift, bracket, dashes, accordion-registration, eyeglasses, damp, damp-all, scordatura, harp-pedals, other-direction (`<words>` already worked) |
| Harmony / figured bass | `<harmony>`, `<kind>`, `<frame>`, `<figured-bass>` (and its `<extend>`) |
| Attributes | `<key>`, `<time>`, `<clef>`, `<measure-style>` |
| Barlines | `<bar-style>`, `<ending>` |
| Part list / credits | `<part-name>`, `<part-abbreviation>`, `<group-name>`, `<group-abbreviation>`, `<group-symbol>`, `<display-text>`, `<credit-words>` |

`<tuplet>`, `<image>` and `<swing>` have no `color` attribute in the MusicXML schema, so they are deliberately left alone — the serializer never writes one on them, and there is a test asserting that.

Values (`#RRGGBB` and the alpha-first `#AARRGGBB` form) are carried through verbatim.

## New API

```typescript
import { setColor, clearColors, ALL_COLOR_TARGETS } from 'musicxml-io';

// Every note in measures 5-6 of the first part, red
const marked = setColor(score, {
  color: '#FF0000',
  partIndices: [0],
  measureNumbers: [5, 6],
});

// One note plus its stem and beams
const highlighted = setColor(score, {
  color: '#0000FF',
  targets: ['note', 'stem', 'beam'],
  noteFilter: (n) => n._id === noteId,
});

// Strip every colour, including the part-list and credit colours
// setColor's targets don't cover
const plain = clearColors(marked);
```

`setColor` selects by part index or ID, measure number, a note predicate, and a list of element kinds (`ColorTarget`; `ALL_COLOR_TARGETS` is exported for "everything"). `color: null` removes a colour. Both functions return a new `Score` and leave the input untouched — they return `Score` rather than `OperationResult<Score>` because a colour change cannot make a score musically invalid.

Elements outside the target list still round-trip and are set by assigning the field directly (`partInfo.nameColor = '#FF0000'`), since colour is an ordinary property on the model.

Colour is presentation only — MIDI export, playback timelines and ABC serialization are unaffected.

## Notes on modelling choices

- **`dotColor` / `noteTypeColor`** — dots are modelled as a count, not as objects, so `dotColor` is written to every `<dot>` and reads the first one's colour.
- **`barStyleColor`** — `<barline>` itself has no `color` attribute; the colour lives on `<bar-style>`, so it is only written when `barStyle` is set.
- **`lyric.textColor`** — the colour of the first `<text>`; per-element colours across an elision live on `textElements[i].color`.

## Test plan

- New `tests/color.test.ts` (30 tests): parse, serialize and parse-serialize-parse for every element group above; the `<tuplet>`/`<image>`/`<swing>` exclusions; and the `setColor` / `clearColors` behaviour (defaults, sub-element targets, selectors, `null` clearing, immutability, survival through serialization).
- New `tests/fixtures/color-elements.musicxml` fixture with 52 `color` attributes across all element kinds — picked up by the existing deep-equality round-trip suite, plus a test asserting the serialized output keeps all 52.
- Full suite: 1129 passed (21 files). `npm run typecheck`, `npm run lint` (0 errors) and `npm run build` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_018bGYvDozmxt6ftrcVwmRQR)_